### PR TITLE
V2

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ async function createSettings(settingsHtml) {
         saveSettingsDebounced();
     });
 
-    // 添加提示词注入设置的事件处理
+    // 添加提示词注入设置的事件 处理
     $('#prompt_injection_enabled').on('change', function () {
         extension_settings[extensionName].promptInjection.enabled = $(this).prop('checked');
         saveSettingsDebounced();
@@ -363,22 +363,17 @@ async function handleIncomingMessage() {
 
         // 5. 保存聊天记录
         await context.saveChat();
-  toastr.success("开始正则触发")
+
+
+
+                        }
+                    }
+                }
+                  toastr.success("开始正则触发")
         // 2. 手动触发正则重新处理（关键步骤）
         // 场景指定为AI输出，确保所有AI相关的正则脚本生效
         modifiedMes = getRegexedString(modifiedMes, regex_placement.AI_OUTPUT);
   toastr.success("结束正则触发")
-
-        // 6. 可选：触发消息更新事件，确保其他组件同步
-        // eventSource.dispatchEvent(new CustomEvent(event_types.MESSAGE_UPDATED, {
-        //     detail: {
-        //         messageId: context.chat.length - 1,
-        //         message: message
-        //     }
-        // }));
-                        }
-                    }
-                }
                 toastr.success(`${tagMatches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);

--- a/index.js
+++ b/index.js
@@ -9,12 +9,6 @@ import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
 import { addCopyToCodeBlocks } from "../../../../script.js"; 
-import { 
-    updateMessageBlock, 
-    addCopyToCodeBlocks, 
-    eventSource, 
-    event_types  
-} from "../../../../script.js";
 
 // 扩展名称和路径
 const extensionName = "st-image-auto-generation";
@@ -341,37 +335,17 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-            // 1. 匹配并替换 <pic> 标签（逻辑不变）
-        const matches = [...message.mes.matchAll(imgTagRegex)];
-        const originalMatch = matches[0];
-        if (!originalMatch) return;
-        const originalTag = originalMatch[0];
-        const prompt = originalMatch[1];
-        const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" class="st-generated-image" title="${prompt}" alt="${prompt}" />`;
-        message.mes = message.mes.replace(originalTag, newImageTag);
+                                   // Find the original image tag in the message
+                            const originalTag = message.mes.match(imgTagRegex)[0];
+                            // Replace it with an actual image tag
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" >`;
+                            message.mes = message.mes.replace(originalTag, newImageTag);
 
-        // 2. 清除 display_text 缓存（避免 ST 用旧内容）
-        if (message.extra) {
-            message.extra.display_text = null;
-        }
+                            // Update the message display using updateMessageBlock
+                            updateMessageBlock(context.chat.length - 1, message);
 
-        // 3. 更新消息 UI（触发基础渲染）
-        const messageId = context.chat.length - 1;
-        updateMessageBlock(messageId, message);
-
-        // 4. 关键：触发 ST 消息更新事件，通知正则插件重新处理
-        // （模拟“手动开关插件”的效果，正则插件会监听这个事件）
-        eventSource.emit(event_types.MESSAGE_MODIFIED, {
-            messageId: messageId,
-            message: message
-        });
-
-        // 5. 补充代码块功能（确保复制按钮生效）
-        const messageElement = $(`.mes[mesid="${messageId}"]`);
-        addCopyToCodeBlocks(messageElement);
-
-        // 6. 保存聊天
-        await context.saveChat();
+                            // Save the chat
+                            await context.saveChat();
                         }
                     }
 

--- a/index.js
+++ b/index.js
@@ -338,7 +338,7 @@ async function handleIncomingMessage() {
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
                             const newImageTag = `<img src="${imageUrl}" promot="${prompt}">`;
-                            alert(originalTag +' '+newImageTag)
+                 
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -195,7 +195,6 @@ $(function () {
         });
     })();
 });
-
 // 获取消息角色
 function getMesRole() {
     // 确保对象路径存在
@@ -276,20 +275,11 @@ async function handleIncomingMessage() {
         return;
     }
 
-    // 使用正则表达式匹配
+    // 使用正则表达式search
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-    // 保存完整匹配结果（包含完整标签和捕获组）
-    let matches;
-    if (imgTagRegex.global) {
-        matches = [...message.mes.matchAll(imgTagRegex)]; // 全局匹配时获取所有完整match对象
-    } else {
-        const singleMatch = message.mes.match(imgTagRegex);
-        matches = singleMatch ? [singleMatch] : []; // 非全局匹配时处理单个结果
-    }
-  //alert(matches)
-                    toastr.success(`开始生成图片`);
-
-    console.log(`[${extensionName}] 匹配到的完整标签:`, matches.map(m => m[0]));
+    // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
+    let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
+    console.log(imgTagRegex, matches)
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {
@@ -297,6 +287,8 @@ async function handleIncomingMessage() {
                 toastr.info(`Generating ${matches.length} images...`);
                 const insertType = extension_settings[extensionName].insertType;
 
+
+                // 在当前消息中插入图片
                 // 初始化message.extra
                 if (!message.extra) {
                     message.extra = {};
@@ -317,21 +309,18 @@ async function handleIncomingMessage() {
 
                 // 处理每个匹配的图片标签
                 for (let i = 0; i < matches.length; i++) {
-                    const match = matches[i];
-                    const prompt = match[1]; // 从捕获组获取prompt
-                    const originalTag = match[0]; // 从完整匹配结果获取原始标签
+                    const prompt = matches[i];
 
-                    // 调用生图接口
                     // @ts-ignore
                     const result = await SlashCommandParser.commands['sd'].callback({ quiet: insertType === INSERT_TYPE.NEW_MESSAGE ? 'false' : 'true' }, prompt);
-                    
+                    // 统一插入到extra里
                     if (insertType === INSERT_TYPE.INLINE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
                             // 添加图片到swipes数组
                             message.extra.image_swipes.push(imageUrl);
 
-                            // 设置主图片
+                            // 设置第一张图片为主图片，或更新为最新生成的图片
                             message.extra.image = imageUrl;
                             message.extra.title = prompt;
                             message.extra.inline_image = true;
@@ -345,23 +334,26 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // 使用初始匹配保存的原始标签进行替换，无需重新匹配
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}">`;
+                            // Find the original image tag in the message
+                            const originalTag = message.mes.match(imgTagRegex)[0];
+                            // Replace it with an actual image tag
+                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
-                            // 更新消息显示
+                            // Update the message display using updateMessageBlock
                             updateMessageBlock(context.chat.length - 1, message);
 
-                            // 保存聊天
+                            // Save the chat
                             await context.saveChat();
                         }
                     }
+
                 }
                 toastr.success(`${matches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);
                 console.error('Image generation error:', error);
             }
-        }, 0); // 防阻塞UI渲染
+        }, 0); //防阻塞UI渲染
     }
 }

--- a/index.js
+++ b/index.js
@@ -408,20 +408,22 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-// 生成3个随机小写字母（a-z）
-const randomLetters = Array.from({ length: 3 }, () => 
-  String.fromCharCode(Math.floor(Math.random() * 26) + 97) // 97是'a'的ASCII码
-);
 
-// 组合成包含3个随机字母和1个'j'的数组，然后随机打乱顺序（确保'j'位置不固定）
-const chars = [...randomLetters, 'j'].sort(() => Math.random() - 0.5);
+							// 1. 生成5位字符数组：包含1个固定'z' + 4个随机小写字母（a-z，可含重复）
+const chars = [
+  'z', // 固定字母z
+  ...Array.from({ length: 4 }, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)) // 4个随机小写字母
+];
 
-// 拼接成4位字符串（格式：3个随机字母+1个'j'，位置随机）
-const randomChars = chars.join('');
+// 2. 随机打乱数组顺序，确保z的位置不固定
+chars.sort(() => Math.random() - 0.5);
 
-// 生成最终的img标签
-const newImageTag = `<img src="${imageUrl}" prompt="${prompt}dmzz" >`;
-                            message.mes = message.mes.replace(originalTag, newImageTag);
+// 3. 拼接成"dmzz_5位字符"格式（如dmzz_zhjuy、dmzz_cdyjz）
+const dmzzStr = `dmzz_${chars.join('')}`;
+
+// 4. 生成最终img标签
+const newImageTag = `<img src="${imageUrl}" prompt="${prompt},${dmzzStr}" >`;
+message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock
                             updateMessageBlock(context.chat.length - 1, message);

--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ async function handleIncomingMessage() {
 
                 // 获取消息元素用于稍后更新
                 const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
-                alert(matches.length)
+
                 // 处理每个匹配的图片标签
                 for (let i = 0; i < matches.length; i++) {
                     const prompt = matches[i];
@@ -335,12 +335,9 @@ async function handleIncomingMessage() {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
                             // Find the original image tag in the message
-                            alert(imgTagRegex)
                             const originalTag = message.mes.match(imgTagRegex)[0];
-                                            alert(originalTag)
-
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" >`;
+                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock } f
 import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
+import { getRegexedString, regex_placement } from '../../../extensions/regex/index.js'; // 引入正则核心函数
 
 // 扩展名称和路径
 const extensionName = "st-image-auto-generation";
@@ -350,13 +351,30 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // 直接使用预存的原始标签进行替换
-                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
-                            message.mes = message.mes.replace(originalTag, newImageTag);
-                            // 更新消息显示
-                            updateMessageBlock(context.chat.length - 1, message);
-                            // 保存聊天
-                            await context.saveChat();
+                            // 1. 替换原始标签为img标签
+        const newImageTag = `<img src="${imageUrl}" promot="${prompt}">`;
+        let modifiedMes = message.mes.replace(originalTag, newImageTag);
+
+        // 2. 手动触发正则重新处理（关键步骤）
+        // 场景指定为AI输出，确保所有AI相关的正则脚本生效
+        modifiedMes = getRegexedString(modifiedMes, regex_placement.AI_OUTPUT);
+
+        // 3. 更新消息内容
+        message.mes = modifiedMes;
+
+        // 4. 更新UI显示
+        updateMessageBlock(context.chat.length - 1, message);
+
+        // 5. 保存聊天记录
+        await context.saveChat();
+
+        // 6. 可选：触发消息更新事件，确保其他组件同步
+        eventSource.dispatchEvent(new CustomEvent(event_types.MESSAGE_UPDATED, {
+            detail: {
+                messageId: context.chat.length - 1,
+                message: message
+            }
+        }));
                         }
                     }
                 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+@@ -1,436 +1,436 @@
 // The main script for the extension
 // The following are examples of some basic extension functionality
 
@@ -216,6 +217,71 @@ function getMesRole() {
     }
 }
 
+/**
+ * 根据名称查找全局正则脚本的ID
+ * @param {string} scriptName - 要查找的正则脚本名称
+ * @returns {string|null} 匹配的全局正则ID，未找到则返回null
+ */
+function findGlobalRegexIdByName(scriptName) {
+    // 处理输入名称（统一小写+去空格，避免匹配差异）
+    const targetName = scriptName.toLowerCase().trim();
+
+    // 校验全局正则数组是否存在
+    if (!Array.isArray(extension_settings.regex)) {
+        console.warn('全局正则脚本数组不存在');
+        return null;
+    }
+
+    // 遍历全局正则数组，匹配名称
+    const matchedScript = extension_settings.regex.find(script => {
+        // 脚本名称可能为undefined，需先判断
+        if (typeof script.scriptName !== 'string') return false;
+        // 统一处理脚本名称后比较
+        return script.scriptName.toLowerCase().trim() === targetName;
+    });
+
+    // 返回找到的ID或null
+    return matchedScript ? matchedScript.id : null;
+}
+function simulateRegexToggle(regexId) {
+    // 延迟执行，确保DOM已渲染（SillyTavern消息渲染可能有延迟）
+    setTimeout(() => {
+        // 直接通过ID定位正则容器（基于用户提供的DOM结构）
+        const scriptContainer = document.getElementById(regexId);
+        if (!scriptContainer) {
+                          //  alert(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`)
+
+            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`);
+            return;
+        }
+
+        // 验证容器类型
+        if (!scriptContainer.classList.contains('regex-script-label')) {
+            console.warn(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
+            //alert(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
+            return;
+        }
+
+        // 查找开关按钮（基于用户提供的class="disable_regex"）
+        const toggleCheckbox = scriptContainer.querySelector('.disable_regex');
+        if (!toggleCheckbox) {
+            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
+            //alert(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
+            return;
+        }
+
+        // 触发点击事件
+        toggleCheckbox.click();
+        console.log(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
+
+        // alert(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
+        toastr.success(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
+
+    }, 200); // 100ms延迟确保DOM就绪
+}
+
+
+
 // 监听CHAT_COMPLETION_PROMPT_READY事件以注入提示词
 eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventData) {
     try {
@@ -276,13 +342,10 @@ async function handleIncomingMessage() {
     }
 
     // 使用正则表达式search
-    const imgTagRegex = /<img\b(?=(?:(?!dmzz).)*?prompt="((?:(?!dmzz).)*?)")[^>]*>/g;
+    const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
     // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
     let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
     console.log(imgTagRegex, matches)
-    if(matches.length == 0){
-         toastr.success( message.mes ? message.mes.substring(0, 1000) : '');
-    }
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {
@@ -340,7 +403,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt},dmzz">`;
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" current_datetime="2025100522${i}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock
@@ -352,6 +415,18 @@ async function handleIncomingMessage() {
                     }
 
                 }
+
+				 // 1. 先通过正则名称查找ID（这里假设要操作的正则名称是"状态栏美化"，可根据实际修改）
+                const targetRegexName = "状态栏美化"; // 替换为你的正则脚本名称
+                const targetRegexId = findGlobalRegexIdByName(targetRegexName);
+
+                if (targetRegexId) {
+                    // 2. 模拟点击开关（切换状态）
+                    simulateRegexToggle(targetRegexId);
+                } else {
+                    alert(`[${extensionName}] 未找到名称为"${targetRegexName}"的全局正则脚本`);
+                }
+
                 toastr.success(`${matches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);

--- a/index.js
+++ b/index.js
@@ -441,7 +441,7 @@ async function handleIncomingMessage() {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
                             // 直接使用预存的原始标签进行替换
-                            const newImageTag = `<img src="${imageUrl}"  promot="${prompt}">`;
+                            const newImageTag = `<img src="${imageUrl}"  prompt="${prompt}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
                             // 更新消息显示
                             updateMessageBlock(context.chat.length - 1, message);

--- a/index.js
+++ b/index.js
@@ -78,7 +78,34 @@ function findGlobalRegexIdByName(scriptName) {
     // 返回找到的ID或null
     return matchedScript ? matchedScript.id : null;
 }
+function simulateRegexToggle(regexId) {
+    // 延迟执行，确保DOM已渲染（SillyTavern消息渲染可能有延迟）
+    setTimeout(() => {
+        // 直接通过ID定位正则容器（基于用户提供的DOM结构）
+        const scriptContainer = document.getElementById(regexId);
+        if (!scriptContainer) {
+            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`);
+            return;
+        }
 
+        // 验证容器类型
+        if (!scriptContainer.classList.contains('regex-script-label')) {
+            console.warn(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
+            return;
+        }
+
+        // 查找开关按钮（基于用户提供的class="disable_regex"）
+        const toggleCheckbox = scriptContainer.querySelector('.disable_regex');
+        if (!toggleCheckbox) {
+            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
+            return;
+        }
+
+        // 触发点击事件
+        toggleCheckbox.click();
+        console.log(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
+    }, 5000); // 100ms延迟确保DOM就绪
+}
 function toggleGlobalRegexState(regexId) {
     // 校验全局正则数组是否存在
     if (!Array.isArray(extension_settings.regex)) {
@@ -244,6 +271,18 @@ $(function () {
                 updateUI();
             }, 200);
         });
+
+
+              const targetRegexName = "状态栏美化"; // 替换为你的正则脚本名称
+                const targetRegexId = findGlobalRegexIdByName(targetRegexName);
+                
+                if (targetRegexId) {
+                    // 2. 模拟点击开关（切换状态）
+                    simulateRegexToggle(targetRegexId);
+                } else {
+                    console.warn(`[${extensionName}] 未找到名称为"${targetRegexName}"的全局正则脚本`);
+                }
+        
     })();
 });
 // 获取消息角色
@@ -411,8 +450,18 @@ async function handleIncomingMessage() {
                         }
                     }
                 }
-             alert(findGlobalRegexIdByName('状态栏美化'));
-        toggleGlobalRegexState(findGlobalRegexIdByName('状态栏美化'));
+
+                // 1. 先通过正则名称查找ID（这里假设要操作的正则名称是"状态栏美化"，可根据实际修改）
+                const targetRegexName = "状态栏美化"; // 替换为你的正则脚本名称
+                const targetRegexId = findGlobalRegexIdByName(targetRegexName);
+                
+                if (targetRegexId) {
+                    // 2. 模拟点击开关（切换状态）
+                    simulateRegexToggle(targetRegexId);
+                } else {
+                    console.warn(`[${extensionName}] 未找到名称为"${targetRegexName}"的全局正则脚本`);
+                }
+                
                 toastr.success(`${tagMatches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 //You'll likely need to import extension_settings, getContext, and loadExtensionSettings from extensions.js
 import { extension_settings, getContext } from "../../../extensions.js";
 //You'll likely need to import some other functions from the main script
-import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock } from "../../../../script.js";
+import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock, parseMarkdown } from "../../../../script.js";
 import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
@@ -333,25 +333,25 @@ async function handleIncomingMessage() {
                         }
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
-                        if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                             const originalTag = message.mes.match(imgTagRegex)[0];
+    if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
+        // 1. 匹配原始 <pic> 标签并替换为 <img> 标签（和之前一样）
+        const originalTag = message.mes.match(imgTagRegex)[0];
         const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" class="st-generated-image" >`;
-        // 步骤1：修改消息文本
         message.mes = message.mes.replace(originalTag, newImageTag);
 
-        // 关键新增：手动触发 Markdown 重新解析（核心修复）
-        // 注：ST 通常用 window.markdownit 或 context.markdown 解析，若下方不生效，可尝试替换为 context.markdown.render(message.mes)
-        const parsedHtml = window.markdownit().render(message.mes);
+        // 2. 关键修复：用 ST 原生解析函数处理 message.mes（含代码块）
+        // 此时 parsedHtml 已包含 <pre><code> 格式的代码块
+        const parsedHtml = parseMarkdown(message.mes); 
 
-        // 步骤2：直接更新 DOM 中的消息内容（替换 updateMessageBlock）
-        const messageElement = $(`.mes[mesid="${context.chat.length - 1}"] .mes-content`);
-        if (messageElement.length) {
-            messageElement.html(parsedHtml); // 用解析后的 HTML 覆盖，而非原始文本
-        }
+        // 3. 给 message 对象添加“已解析的HTML”属性（ST 原生识别）
+        // 部分 ST 版本的 updateMessageBlock 会优先使用 parsedContent 而非原始 mes
+        message.parsedContent = parsedHtml; 
 
-                            // Save the chat
-                            await context.saveChat();
-                        }
+        // 4. 调用 updateMessageBlock 更新 UI（此时会用 parsedContent 渲染）
+        updateMessageBlock(context.chat.length - 1, message);
+
+        await context.saveChat();
+    }
                     }
 
                 }

--- a/index.js
+++ b/index.js
@@ -276,10 +276,13 @@ async function handleIncomingMessage() {
     }
 
     // 使用正则表达式search
-    const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
+    const imgTagRegex = /<img\b(?=(?:(?!dmzz).)*?prompt="((?:(?!dmzz).)*?)")[^>]*>/g;
     // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
     let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
     console.log(imgTagRegex, matches)
+    if(matches.length == 0){
+         toastr.success( message.mes ? message.mes.substring(0, 1000) : '');
+    }
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {

--- a/index.js
+++ b/index.js
@@ -387,6 +387,10 @@ async function handleIncomingMessage() {
         }
     }
 
+    if(tagMatches.length == 0){
+        alert(imgTagRegex)
+        alert(message.mes.matchAll(imgTagRegex))
+    }
     if (tagMatches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {

--- a/index.js
+++ b/index.js
@@ -342,8 +342,8 @@ async function handleIncomingMessage() {
     }
 
     // 使用正则表达式search
-   // const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-const imgTagRegex = /<[\s\r\n]*img(?!(?:(?!>).)*?current_datetime\s*=\s*"[^"]*2025100522[^"]*")[^>]*?prompt\s*=\s*"([^"]*)"[^>]*?>/gis;
+    const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
+//const imgTagRegex = /<[\s\r\n]*img(?!(?:(?!>).)*?current_datetime\s*=\s*"[^"]*2025100522[^"]*")[^>]*?prompt\s*=\s*"([^"]*)"[^>]*?>/gis;
 	let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
     console.log(imgTagRegex, matches)
 
@@ -408,7 +408,7 @@ const imgTagRegex = /<[\s\r\n]*img(?!(?:(?!>).)*?current_datetime\s*=\s*"[^"]*20
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" current_datetime="2025100522${i}">`;
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt},dmzz" >`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -420,7 +420,7 @@ const chars = [...randomLetters, 'j'].sort(() => Math.random() - 0.5);
 const randomChars = chars.join('');
 
 // 生成最终的img标签
-const newImageTag = `<img src="${imageUrl}" prompt="${prompt},${randomChars}" >`;
+const newImageTag = `<img src="${imageUrl}" prompt="${prompt}dmzz" >`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -388,8 +388,8 @@ async function handleIncomingMessage() {
     }
 
     if(tagMatches.length == 0){
-        alert(imgTagRegex)
-        alert(message.mes.matchAll(imgTagRegex))
+        alert(imgTagRegex + "  "+imgTagRegex.global)
+                alert(message.mes)
     }
     if (tagMatches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock } f
 import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
-import { getRegexedString, regex_placement } from '../../../extensions/regex/index.js'; // 引入正则核心函数
+import { getRegexedString, regex_placement } from '../../../extensions/regex/engine.js';
 
 // 扩展名称和路径
 const extensionName = "st-image-auto-generation";

--- a/index.js
+++ b/index.js
@@ -322,7 +322,7 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventDa
  eventSource.on(event_types.MESSAGE_RECEIVED, () => {
      // 事件触发时立即保存当前聊天索引（快照）
      //const targetMessageIndex = context.chat.length - 1; 
-     setTimeout(() => handleIncomingMessage(), 500);
+     setTimeout(() => handleIncomingMessage, 500);
  });
 
 async function handleIncomingMessage() {
@@ -349,9 +349,11 @@ async function handleIncomingMessage() {
 
     // 使用正则表达式search
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
+	alert(imgTagRegex)
     // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
     let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
-    console.log(imgTagRegex, matches)
+    alert(imgTagRegex, matches)
+	alert(matches.length)
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {

--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" >`;
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" >`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -407,7 +407,8 @@ async function handleIncomingMessage() {
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
-                            // Replace it with an actual image tag
+                            alert(originalTag)
+							// Replace it with an actual image tag
 
 							// 1. 生成5位字符数组：包含1个固定'z' + 4个随机小写字母（a-z，可含重复）
 const chars = [
@@ -423,7 +424,8 @@ const dmzzStr = `dmzz_${chars.join('')}`;
 
 // 4. 生成最终img标签
 const newImageTag = `<img src="${imageUrl}" prompt="${prompt},${dmzzStr}" >`;
-message.mes = message.mes.replace(originalTag, newImageTag);
+alert(newImageTag)
+							message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock
                             updateMessageBlock(context.chat.length - 1, message);

--- a/index.js
+++ b/index.js
@@ -408,7 +408,12 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt},dmzz" >`;
+							// 生成4位随机小写英文字符（a-z）
+const randomChars = Array.from({ length: 4 }, () => 
+  String.fromCharCode(Math.floor(Math.random() * 26) + 97) // 97是'a'的ASCII码，26个字母
+).join('');
+							
+                           const newImageTag = `<img src="${imageUrl}" prompt="${prompt},${randomChars}" >`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -343,7 +343,7 @@ async function handleIncomingMessage() {
 
     // 使用正则表达式search
    // const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-const imgTagRegex = /<\s*img\b(?![^>]*current_datetime="[^"]*2025100522[^"]*")(?=[^>]*prompt="([^"]*)")[^>]*>/g;
+const imgTagRegex = /<[\s\r\n]*img(?!(?:(?!>).)*?current_datetime\s*=\s*"[^"]*2025100522[^"]*")[^>]*?prompt\s*=\s*"([^"]*)"[^>]*?>/gis;
 	let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
     console.log(imgTagRegex, matches)
 

--- a/index.js
+++ b/index.js
@@ -250,9 +250,6 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventDa
         toastr.error(`提示词注入错误: ${error}`);
     }
 });
-
-// 监听消息接收事件
-eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
 // 监听消息接收事件
 eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
 async function handleIncomingMessage() {
@@ -353,39 +350,12 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                              // 1. 先更新消息数据模型（保持与视图同步）
-                            const originalTag = message.mes.match(imgTagRegex)[0];
-                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}" class="generated-image">`;
+                            // 直接使用预存的原始标签进行替换
+                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
-
-                            // 2. 同步更新message.extra（SillyTavern依赖此数据渲染图片控件）
-                            if (!message.extra) message.extra = {};
-                            if (!Array.isArray(message.extra.image_swipes)) {
-                                message.extra.image_swipes = [];
-                            }
-                            message.extra.image_swipes.push(imageUrl);
-                            message.extra.image = imageUrl; // 主图指向当前生成的图片
-                            message.extra.title = prompt;
-
-                            // 3. 局部更新DOM，保留其他HTML美化内容
-                            const escapedTag = originalTag.replace(/[!"#$%&'()*+,.\/:;<=>?@[\]^_`{|}~]/g, '\\$&');
-                            const targetElement = messageElement.find(`:contains("${escapedTag}")`).filter(function() {
-                                return $(this).html().includes(originalTag);
-                            });
-
-                            if (targetElement.length) {
-                                // 替换标签为图片HTML
-                                targetElement.html(targetElement.html().replace(originalTag, newImageTag));
-                                // 触发SillyTavern的图片加载逻辑（模拟原生渲染行为）
-                                targetElement.find('img.generated-image').on('load', function() {
-                                    messageElement.find('.message-content').trigger('rendered');
-                                });
-                            }
-
-                            // 4. 调用轻量更新方法，只刷新媒体部分（避免全量HTML替换）
-                            appendMediaToMessage(message, messageElement);
-                            
-                            // 5. 保存聊天记录（触发内部状态同步）
+                            // 更新消息显示
+                            updateMessageBlock(context.chat.length - 1, message);
+                            // 保存聊天
                             await context.saveChat();
                         }
                     }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 //You'll likely need to import extension_settings, getContext, and loadExtensionSettings from extensions.js
 import { extension_settings, getContext } from "../../../extensions.js";
 //You'll likely need to import some other functions from the main script
-import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock, parseMarkdown } from "../../../../script.js";
+import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock } from "../../../../script.js";
 import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
@@ -333,25 +333,19 @@ async function handleIncomingMessage() {
                         }
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
-    if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-        // 1. 匹配原始 <pic> 标签并替换为 <img> 标签（和之前一样）
-        const originalTag = message.mes.match(imgTagRegex)[0];
-        const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" class="st-generated-image" >`;
-        message.mes = message.mes.replace(originalTag, newImageTag);
+                        if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
+                            // Find the original image tag in the message
+                            const originalTag = message.mes.match(imgTagRegex)[0];
+                            // Replace it with an actual image tag
+                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
+                            message.mes = message.mes.replace(originalTag, newImageTag);
 
-        // 2. 关键修复：用 ST 原生解析函数处理 message.mes（含代码块）
-        // 此时 parsedHtml 已包含 <pre><code> 格式的代码块
-        const parsedHtml = parseMarkdown(message.mes); 
+                            // Update the message display using updateMessageBlock
+                            updateMessageBlock(context.chat.length - 1, message);
 
-        // 3. 给 message 对象添加“已解析的HTML”属性（ST 原生识别）
-        // 部分 ST 版本的 updateMessageBlock 会优先使用 parsedContent 而非原始 mes
-        message.parsedContent = parsedHtml; 
-
-        // 4. 调用 updateMessageBlock 更新 UI（此时会用 parsedContent 渲染）
-        updateMessageBlock(context.chat.length - 1, message);
-
-        await context.saveChat();
-    }
+                            // Save the chat
+                            await context.saveChat();
+                        }
                     }
 
                 }
@@ -363,4 +357,3 @@ async function handleIncomingMessage() {
         }, 0); //防阻塞UI渲染
     }
 }
-

--- a/index.js
+++ b/index.js
@@ -198,12 +198,37 @@ $(function () {
         alert(findGlobalRegexIdByName('状态栏美化'))
 
  
-
+toggleGlobalRegexState(findGlobalRegexIdByName('状态栏美化'))
         
-toggleGlobalRegex(findGlobalRegexIdByName('状态栏美化'),false)
         
     })();
 });
+
+function toggleGlobalRegexState(regexId) {
+    // 校验全局正则数组是否存在
+    if (!Array.isArray(extension_settings.regex)) {
+        console.warn('全局正则脚本数组不存在');
+        return false;
+    }
+
+    // 根据ID查找目标正则脚本
+    const targetScript = extension_settings.regex.find(script => script.id === regexId);
+    if (!targetScript) {
+        console.warn(`未找到ID为 ${regexId} 的全局正则脚本`);
+        return false;
+    }
+
+    // 取反当前状态（disabled为true表示禁用，取反后启用，反之亦然）
+    const originalState = targetScript.disabled;
+    targetScript.disabled = !originalState;
+
+    // 保存设置（延迟保存避免频繁操作）
+    saveSettingsDebounced();
+
+    // 输出状态变更信息
+    console.log(`全局正则脚本 ${regexId} 已${targetScript.disabled ? '禁用' : '启用'}`);
+    return true;
+}
 function findGlobalRegexIdByName(scriptName) {
     // 处理输入名称（统一小写+去空格，避免匹配差异）
     const targetName = scriptName.toLowerCase().trim();

--- a/index.js
+++ b/index.js
@@ -353,26 +353,39 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // 1. 创建新的img元素（保留提示词作为标题和alt）
-                            const imgElement = $(`<img src="${imageUrl}" title="${prompt}" alt="${prompt}" class="auto-generated-image">`);
-                            
-                            // 2. 找到消息DOM中对应的<pic>标签节点
-                            // 注意：需要从原始标签文本创建选择器（转义特殊字符）
+                              // 1. 先更新消息数据模型（保持与视图同步）
+                            const originalTag = message.mes.match(imgTagRegex)[0];
+                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}" class="generated-image">`;
+                            message.mes = message.mes.replace(originalTag, newImageTag);
+
+                            // 2. 同步更新message.extra（SillyTavern依赖此数据渲染图片控件）
+                            if (!message.extra) message.extra = {};
+                            if (!Array.isArray(message.extra.image_swipes)) {
+                                message.extra.image_swipes = [];
+                            }
+                            message.extra.image_swipes.push(imageUrl);
+                            message.extra.image = imageUrl; // 主图指向当前生成的图片
+                            message.extra.title = prompt;
+
+                            // 3. 局部更新DOM，保留其他HTML美化内容
                             const escapedTag = originalTag.replace(/[!"#$%&'()*+,.\/:;<=>?@[\]^_`{|}~]/g, '\\$&');
-                            const picElement = messageElement.find(`:contains("${escapedTag}")`).filter(function() {
-                                // 精确匹配包含原始标签的文本节点的父元素
+                            const targetElement = messageElement.find(`:contains("${escapedTag}")`).filter(function() {
                                 return $(this).html().includes(originalTag);
                             });
 
-                            if (picElement.length) {
-                                // 3. 直接替换DOM中的<pic>标签为img元素（不影响其他HTML）
-                                picElement.html(function(index, html) {
-                                    return html.replace(originalTag, imgElement.prop('outerHTML'));
+                            if (targetElement.length) {
+                                // 替换标签为图片HTML
+                                targetElement.html(targetElement.html().replace(originalTag, newImageTag));
+                                // 触发SillyTavern的图片加载逻辑（模拟原生渲染行为）
+                                targetElement.find('img.generated-image').on('load', function() {
+                                    messageElement.find('.message-content').trigger('rendered');
                                 });
                             }
 
-                            // 4. 同步更新message.mes（确保保存时内容正确，不影响已渲染DOM）
-                            message.mes = message.mes.replace(originalTag, imgElement.prop('outerHTML'));
+                            // 4. 调用轻量更新方法，只刷新媒体部分（避免全量HTML替换）
+                            appendMediaToMessage(message, messageElement);
+                            
+                            // 5. 保存聊天记录（触发内部状态同步）
                             await context.saveChat();
                         }
                     }

--- a/index.js
+++ b/index.js
@@ -408,12 +408,19 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-							// 生成4位随机小写英文字符（a-z）
-const randomChars = Array.from({ length: 4 }, () => 
-  String.fromCharCode(Math.floor(Math.random() * 26) + 97) // 97是'a'的ASCII码，26个字母
-).join('');
-							
-                           const newImageTag = `<img src="${imageUrl}" prompt="${prompt},${randomChars}" >`;
+// 生成3个随机小写字母（a-z）
+const randomLetters = Array.from({ length: 3 }, () => 
+  String.fromCharCode(Math.floor(Math.random() * 26) + 97) // 97是'a'的ASCII码
+);
+
+// 组合成包含3个随机字母和1个'j'的数组，然后随机打乱顺序（确保'j'位置不固定）
+const chars = [...randomLetters, 'j'].sort(() => Math.random() - 0.5);
+
+// 拼接成4位字符串（格式：3个随机字母+1个'j'，位置随机）
+const randomChars = chars.join('');
+
+// 生成最终的img标签
+const newImageTag = `<img src="${imageUrl}" prompt="${prompt},${randomChars}" >`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-@@ -1,436 +1,436 @@
+
 // The main script for the extension
 // The following are examples of some basic extension functionality
 

--- a/index.js
+++ b/index.js
@@ -338,6 +338,7 @@ async function handleIncomingMessage() {
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
                             const newImageTag = `<img src="${imageUrl}" promot="${prompt}">`;
+                            alert(originalTag +' '+newImageTag)
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -342,10 +342,15 @@ async function handleIncomingMessage() {
     }
 
     // 使用正则表达式search
-    const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-    // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-    let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
+   // const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
+const imgTagRegex = /<\s*img\b(?![^>]*current_datetime="[^"]*2025100522[^"]*")(?=[^>]*prompt="([^"]*)")[^>]*>/g;
+	let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
     console.log(imgTagRegex, matches)
+
+	if(matches.length ===0){
+	   toastr.success(message.mes);
+
+	}
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {

--- a/index.js
+++ b/index.js
@@ -338,17 +338,14 @@ async function handleIncomingMessage() {
         const matches = [...message.mes.matchAll(imgTagRegex)];
         // 取第一个匹配的标签（若需处理多标签，可循环）
         const originalMatch = matches[0];
-        if (!originalMatch) return; // 无匹配标签则退出
-        const originalTag = originalMatch[0]; // 完整的 <pic> 标签
-        const prompt = originalMatch[1]; // 提取的 prompt
+        if (!originalMatch) return; 
+        const originalTag = originalMatch[0]; 
+        const prompt = originalMatch[1]; 
 
         // 步骤2：构造符合 ST 渲染规范的 <img> 标签（加 class 适配样式）
         const newImageTag = `<img 
             src="${imageUrl}" 
             prompt="${prompt}" 
-            class="st-generated-image" 
-            alt="Auto-generated image: ${prompt}"  // 加 alt 适配无障碍
-            title="${prompt}"  // 保留 prompt 到 title
         />`;
 
         // 步骤3：修改 message.mes（替换 <pic> 为 <img>）

--- a/index.js
+++ b/index.js
@@ -196,8 +196,27 @@ $(function () {
         });
      
         alert(extension_settings.regex.map(script => script.id))
+
+        
+toggleGlobalRegex('77a627b9-4e0d-4b67-a822-f8be116aa4bc',false)
+        
     })();
 });
+
+function toggleGlobalRegex(regexId, enable) {
+    // 查找对应ID的全局正则脚本
+    const targetScript = extension_settings.regex?.find(script => script.id === regexId);
+    if (!targetScript) {
+        console.warn(`未找到ID为 ${regexId} 的全局正则脚本`);
+        return false;
+    }
+    // 修改disabled属性（enable为true时，disabled设为false，反之亦然）
+    targetScript.disabled = !enable;
+    // 保存设置（延迟保存，避免频繁操作）
+    saveSettingsDebounced();
+    console.log(`全局正则脚本 ${regexId} 已${enable ? '启用' : '禁用'}`);
+    return true;
+}
 // 获取消息角色
 function getMesRole() {
     // 确保对象路径存在

--- a/index.js
+++ b/index.js
@@ -346,7 +346,7 @@ async function handleIncomingMessage() {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
                             // 使用初始匹配保存的原始标签进行替换，无需重新匹配
-                            const newImageTag = `<img src="${imageUrl}" promot="${prompt}">`;
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // 更新消息显示

--- a/index.js
+++ b/index.js
@@ -195,6 +195,7 @@ $(function () {
         });
     })();
 });
+
 // 获取消息角色
 function getMesRole() {
     // 确保对象路径存在
@@ -275,11 +276,18 @@ async function handleIncomingMessage() {
         return;
     }
 
-    // 使用正则表达式search
+    // 使用正则表达式匹配
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-    // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-    let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
-    console.log(imgTagRegex, matches)
+    // 保存完整匹配结果（包含完整标签和捕获组）
+    let matches;
+    if (imgTagRegex.global) {
+        matches = [...message.mes.matchAll(imgTagRegex)]; // 全局匹配时获取所有完整match对象
+    } else {
+        const singleMatch = message.mes.match(imgTagRegex);
+        matches = singleMatch ? [singleMatch] : []; // 非全局匹配时处理单个结果
+    }
+
+    console.log(`[${extensionName}] 匹配到的完整标签:`, matches.map(m => m[0]));
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {
@@ -287,8 +295,6 @@ async function handleIncomingMessage() {
                 toastr.info(`Generating ${matches.length} images...`);
                 const insertType = extension_settings[extensionName].insertType;
 
-
-                // 在当前消息中插入图片
                 // 初始化message.extra
                 if (!message.extra) {
                     message.extra = {};
@@ -309,18 +315,21 @@ async function handleIncomingMessage() {
 
                 // 处理每个匹配的图片标签
                 for (let i = 0; i < matches.length; i++) {
-                    const prompt = matches[i];
+                    const match = matches[i];
+                    const prompt = match[1]; // 从捕获组获取prompt
+                    const originalTag = match[0]; // 从完整匹配结果获取原始标签
 
+                    // 调用生图接口
                     // @ts-ignore
                     const result = await SlashCommandParser.commands['sd'].callback({ quiet: insertType === INSERT_TYPE.NEW_MESSAGE ? 'false' : 'true' }, prompt);
-                    // 统一插入到extra里
+                    
                     if (insertType === INSERT_TYPE.INLINE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
                             // 添加图片到swipes数组
                             message.extra.image_swipes.push(imageUrl);
 
-                            // 设置第一张图片为主图片，或更新为最新生成的图片
+                            // 设置主图片
                             message.extra.image = imageUrl;
                             message.extra.title = prompt;
                             message.extra.inline_image = true;
@@ -334,27 +343,23 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // Find the original image tag in the message
-                            const originalTag = message.mes.match(imgTagRegex)[0];
-                            // Replace it with an actual image tag
+                            // 使用初始匹配保存的原始标签进行替换，无需重新匹配
                             const newImageTag = `<img src="${imageUrl}" promot="${prompt}">`;
-                 
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
-                            // Update the message display using updateMessageBlock
+                            // 更新消息显示
                             updateMessageBlock(context.chat.length - 1, message);
 
-                            // Save the chat
+                            // 保存聊天
                             await context.saveChat();
                         }
                     }
-
                 }
                 toastr.success(`${matches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);
                 console.error('Image generation error:', error);
             }
-        }, 0); //防阻塞UI渲染
+        }, 0); // 防阻塞UI渲染
     }
 }

--- a/index.js
+++ b/index.js
@@ -334,14 +334,20 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // Find the original image tag in the message
-                            const originalTag = message.mes.match(imgTagRegex)[0];
-                            // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" >`;
-                            message.mes = message.mes.replace(originalTag, newImageTag);
+                             const originalTag = message.mes.match(imgTagRegex)[0];
+        const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" class="st-generated-image" >`;
+        // 步骤1：修改消息文本
+        message.mes = message.mes.replace(originalTag, newImageTag);
 
-                            // Update the message display using updateMessageBlock
-                            updateMessageBlock(context.chat.length - 1, message);
+        // 关键新增：手动触发 Markdown 重新解析（核心修复）
+        // 注：ST 通常用 window.markdownit 或 context.markdown 解析，若下方不生效，可尝试替换为 context.markdown.render(message.mes)
+        const parsedHtml = window.markdownit().render(message.mes);
+
+        // 步骤2：直接更新 DOM 中的消息内容（替换 updateMessageBlock）
+        const messageElement = $(`.mes[mesid="${context.chat.length - 1}"] .mes-content`);
+        if (messageElement.length) {
+            messageElement.html(parsedHtml); // 用解析后的 HTML 覆盖，而非原始文本
+        }
 
                             // Save the chat
                             await context.saveChat();

--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt},dmzz">`;
+                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
 import { addCopyToCodeBlocks } from "../../../../script.js"; 
+// 导入必要的变量和函数（如果未导入）
+import { this_chid, characters } from "../../../../script.js";
+// 假设Regex插件的核心处理函数在engine.js中，路径需根据实际情况调整
+import { runRegexScript } from "../../../extensions/regex/engine.js";
 
 // 扩展名称和路径
 const extensionName = "st-image-auto-generation";
@@ -196,6 +200,33 @@ $(function () {
         });
     })();
 });
+
+
+// 新增：重新应用所有启用的正则脚本到指定消息
+function reapplyRegexToMessage(message, messageIndex) {
+    try {
+        // 获取所有需要应用的正则脚本（全局+角色范围）
+        const regexScripts = [
+            // 全局正则脚本（过滤已禁用的）
+            ...(extension_settings.regex || []).filter(script => !script.disabled),
+            // 角色范围正则脚本（过滤已禁用的）
+            ...(characters[this_chid]?.data?.extensions?.regex_scripts || []).filter(script => !script.disabled)
+        ];
+
+        // 对当前消息应用每个正则脚本
+        regexScripts.forEach(script => {
+            // 调用Regex插件的核心处理函数（需与插件实现匹配）
+            // 注意：runRegexScript的参数可能需要调整，参考Regex插件的实际实现
+            runRegexScript(script, message, messageIndex);
+        });
+
+        // 再次更新消息UI，显示正则处理后的结果（包括状态栏）
+        updateMessageBlock(messageIndex, message);
+        console.log(`[${extensionName}] 已重新应用正则到消息，状态栏应正常显示`);
+    } catch (error) {
+        console.error(`[${extensionName}] 重新应用正则失败:`, error);
+    }
+}
 // 获取消息角色
 function getMesRole() {
     // 确保对象路径存在
@@ -348,15 +379,16 @@ const messageElement = $(`.mes[mesid="${messageId}"]`);
                             // Update the message display using updateMessageBlock
                             updateMessageBlock(context.chat.length - 1, message);
 
+        // 3. 主动触发Regex插件重新处理当前消息，修复状态栏正则
+        reapplyRegexToMessage(message, context.chat.length - 1);
+
                             // Save the chat
                             await context.saveChat();
                         }
                     }
 
                 }
-                alert(0);
-                eventSource.emit(event_types.MESSAGE_UPDATED, { messageId: messageId, message: message });
-alert(1);
+ 
                 toastr.success(`${matches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);

--- a/index.js
+++ b/index.js
@@ -8,8 +8,7 @@ import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock } f
 import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
-// 补充导入禁用和启用扩展的函数
-import { extension_settings, getContext, enableExtension, disableExtension } from "../../../extensions.js";
+
 // 扩展名称和路径
 const extensionName = "st-image-auto-generation";
 // /scripts/extensions/third-party
@@ -335,24 +334,17 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // 找到消息中的原始图片标签并替换
-        const originalTag = message.mes.match(imgTagRegex)[0];
-        const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
-        message.mes = message.mes.replace(originalTag, newImageTag);
+                            // Find the original image tag in the message
+                            const originalTag = message.mes.match(imgTagRegex)[0];
+                            // Replace it with an actual image tag
+                            const newImageTag = `<img src="${imageUrl}" >`;
+                            message.mes = message.mes.replace(originalTag, newImageTag);
 
-        // 更新消息显示
-        updateMessageBlock(context.chat.length - 1, message);
+                            // Update the message display using updateMessageBlock
+                            updateMessageBlock(context.chat.length - 1, message);
 
-        // 关键修复：重新触发正则插件以处理状态栏
-        // 1. 先禁用正则插件
-        await disableExtension('regex', false);
-        // 2. 短暂延迟确保禁用生效
-        await new Promise(resolve => setTimeout(resolve, 100));
-        // 3. 重新启用正则插件，使其重新处理所有消息
-        await enableExtension('regex', false);
-
-        // 保存聊天记录
-        await context.saveChat();
+                            // Save the chat
+                            await context.saveChat();
                         }
                     }
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,14 @@ import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
 import { addCopyToCodeBlocks } from "../../../../script.js"; 
+import { 
+    getRegexedString, 
+    regex_placement, 
+    messageFormatting, 
+    addCopyToCodeBlocks,
+    updateMessageBlock
+} from "../../../../script.js";
+
 // 扩展名称和路径
 const extensionName = "st-image-auto-generation";
 // /scripts/extensions/third-party
@@ -334,36 +342,38 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // 步骤1：匹配原始 <pic> 标签（注意：用 matchAll 避免多次匹配时的索引偏移）
+                            // 1. 匹配并替换 <pic> 标签（之前的逻辑不变）
         const matches = [...message.mes.matchAll(imgTagRegex)];
-        // 取第一个匹配的标签（若需处理多标签，可循环）
         const originalMatch = matches[0];
-        if (!originalMatch) return; 
-        const originalTag = originalMatch[0]; 
-        const prompt = originalMatch[1]; 
-
-        // 步骤2：构造符合 ST 渲染规范的 <img> 标签（加 class 适配样式）
-        const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" />`;
-
-        // 步骤3：修改 message.mes（替换 <pic> 为 <img>）
+        if (!originalMatch) return;
+        const originalTag = originalMatch[0];
+        const prompt = originalMatch[1];
+        const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" class="st-generated-image" title="${prompt}" alt="${prompt}" />`;
         message.mes = message.mes.replace(originalTag, newImageTag);
 
-        // 步骤4：关键！删除 extra.display_text（避免 updateMessageBlock 优先用旧文本）
-        if (message.extra && message.extra.display_text) {
-            delete message.extra.display_text;
-            console.log('[ST-Image-Auto-Gen] Deleted old display_text to force Markdown reparse');
+        // 2. 关键：手动调用正则插件的核心函数，处理状态栏正则
+        // 注意：placement 需对应状态栏正则的生效位置（通常是 AI 输出，即 regex_placement.AI_OUTPUT）
+        const placement = regex_placement.AI_OUTPUT; // 从 script.js 导入 regex_placement
+        message.mes = getRegexedString(message.mes, placement, {
+            characterOverride: message.name, // 传递角色名（插件可能需要）
+            isMarkdown: true,
+        });
+
+        // 3. 清除 display_text 缓存，确保 ST 用处理后的 mes
+        if (message.extra) {
+            message.extra.display_text = null;
         }
 
-        // 步骤5：调用 ST 原生 updateMessageBlock，触发全量渲染
-        // 无需传 rerenderMessage，默认 true，会自动调用 messageFormatting 解析代码块
-        updateMessageBlock(context.chat.length - 1, message);
+        // 4. 更新 UI（触发渲染）
+        const messageId = context.chat.length - 1;
+        updateMessageBlock(messageId, message);
 
-        // 步骤6：保存聊天记录（同步修改后的 mes）
-        await context.saveChat();
-
-        // 步骤7：额外保障：手动调用 addCopyToCodeBlocks（确保代码块复制按钮正常）
-        const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
+        // 5. 补充代码块功能
+        const messageElement = $(`.mes[mesid="${messageId}"]`);
         addCopyToCodeBlocks(messageElement);
+
+        // 6. 保存聊天
+        await context.saveChat();
                         }
                     }
 

--- a/index.js
+++ b/index.js
@@ -350,6 +350,8 @@ async function handleIncomingMessage() {
                     }
 
                 }
+                eventSource.emit(event_types.MESSAGE_UPDATED, { messageId: messageId, message: message });
+
                 toastr.success(`${matches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);

--- a/index.js
+++ b/index.js
@@ -253,6 +253,8 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventDa
 
 // 监听消息接收事件
 eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
+// 监听消息接收事件
+eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
 async function handleIncomingMessage() {
     // 确保设置对象存在
     if (!extension_settings[extensionName] ||
@@ -275,18 +277,39 @@ async function handleIncomingMessage() {
         return;
     }
 
-    // 使用正则表达式search
+    // 使用正则表达式一次性匹配所有结果
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-    // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-    let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
-    console.log(imgTagRegex, matches)
-    if (matches.length > 0) {
+    // 存储所有匹配的标签和提示词（完整标签+捕获组内容）
+    const tagMatches = [];
+    
+    // 一次性获取所有匹配项
+    if (imgTagRegex.global) {
+        // 全局匹配时使用matchAll获取所有结果
+        const allMatches = message.mes.matchAll(imgTagRegex);
+        for (const match of allMatches) {
+            // match[0]是完整标签，match[1]是提示词（第一个捕获组）
+            tagMatches.push({
+                tag: match[0],
+                prompt: match[1]
+            });
+        }
+    } else {
+        // 非全局匹配时只取第一个结果
+        const singleMatch = message.mes.match(imgTagRegex);
+        if (singleMatch) {
+            tagMatches.push({
+                tag: singleMatch[0],
+                prompt: singleMatch[1]
+            });
+        }
+    }
+
+    if (tagMatches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {
             try {
-                toastr.info(`Generating ${matches.length} images...`);
+                toastr.info(`Generating ${tagMatches.length} images...`);
                 const insertType = extension_settings[extensionName].insertType;
-
 
                 // 在当前消息中插入图片
                 // 初始化message.extra
@@ -307,53 +330,44 @@ async function handleIncomingMessage() {
                 // 获取消息元素用于稍后更新
                 const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
 
-                // 处理每个匹配的图片标签
-                for (let i = 0; i < matches.length; i++) {
-                    const prompt = matches[i];
-
+                // 循环预存的匹配结果数组
+                for (let i = 0; i < tagMatches.length; i++) {
+                    const { tag: originalTag, prompt } = tagMatches[i];
                     // @ts-ignore
                     const result = await SlashCommandParser.commands['sd'].callback({ quiet: insertType === INSERT_TYPE.NEW_MESSAGE ? 'false' : 'true' }, prompt);
-                    // 统一插入到extra里
+                    
                     if (insertType === INSERT_TYPE.INLINE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
                             // 添加图片到swipes数组
                             message.extra.image_swipes.push(imageUrl);
-
                             // 设置第一张图片为主图片，或更新为最新生成的图片
                             message.extra.image = imageUrl;
                             message.extra.title = prompt;
                             message.extra.inline_image = true;
-
                             // 更新UI
                             appendMediaToMessage(message, messageElement);
-
                             // 保存聊天记录
                             await context.saveChat();
                         }
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // Find the original image tag in the message
-                            const originalTag = message.mes.match(imgTagRegex)[0];
-                            // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
+                            // 直接使用预存的原始标签进行替换
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
-
-                            // Update the message display using updateMessageBlock
+                            // 更新消息显示
                             updateMessageBlock(context.chat.length - 1, message);
-
-                            // Save the chat
+                            // 保存聊天
                             await context.saveChat();
                         }
                     }
-
                 }
-                toastr.success(`${matches.length} images generated successfully`);
+                toastr.success(`${tagMatches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);
                 console.error('Image generation error:', error);
             }
-        }, 0); //防阻塞UI渲染
+        }, 0); // 防阻塞UI渲染
     }
 }

--- a/index.js
+++ b/index.js
@@ -195,14 +195,36 @@ $(function () {
             }, 200);
         });
      
-        alert(extension_settings.regex.map(script => script.id))
+        alert(findGlobalRegexIdByName('状态栏美化'))
+
+ 
 
         
-toggleGlobalRegex('77a627b9-4e0d-4b67-a822-f8be116aa4bc',false)
+toggleGlobalRegex(findGlobalRegexIdByName('状态栏美化'),false)
         
     })();
 });
-
+function findGlobalRegexIdByName(scriptName) {
+    // 处理输入名称（统一小写+去空格，避免匹配差异）
+    const targetName = scriptName.toLowerCase().trim();
+    
+    // 校验全局正则数组是否存在
+    if (!Array.isArray(extension_settings.regex)) {
+        console.warn('全局正则脚本数组不存在');
+        return null;
+    }
+    
+    // 遍历全局正则数组，匹配名称
+    const matchedScript = extension_settings.regex.find(script => {
+        // 脚本名称可能为undefined，需先判断
+        if (typeof script.scriptName !== 'string') return false;
+        // 统一处理脚本名称后比较
+        return script.scriptName.toLowerCase().trim() === targetName;
+    });
+    
+    // 返回找到的ID或null
+    return matchedScript ? matchedScript.id : null;
+}
 function toggleGlobalRegex(regexId, enable) {
     // 查找对应ID的全局正则脚本
     const targetScript = extension_settings.regex?.find(script => script.id === regexId);

--- a/index.js
+++ b/index.js
@@ -286,7 +286,7 @@ async function handleIncomingMessage() {
         const singleMatch = message.mes.match(imgTagRegex);
         matches = singleMatch ? [singleMatch] : []; // 非全局匹配时处理单个结果
     }
-
+  alert(matches)
     console.log(`[${extensionName}] 匹配到的完整标签:`, matches.map(m => m[0]));
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来

--- a/index.js
+++ b/index.js
@@ -84,6 +84,8 @@ function simulateRegexToggle(regexId) {
         // 直接通过ID定位正则容器（基于用户提供的DOM结构）
         const scriptContainer = document.getElementById(regexId);
         if (!scriptContainer) {
+                            alert(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`)
+
             console.warn(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`);
             return;
         }
@@ -91,6 +93,7 @@ function simulateRegexToggle(regexId) {
         // 验证容器类型
         if (!scriptContainer.classList.contains('regex-script-label')) {
             console.warn(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
+            alert(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
             return;
         }
 
@@ -98,13 +101,17 @@ function simulateRegexToggle(regexId) {
         const toggleCheckbox = scriptContainer.querySelector('.disable_regex');
         if (!toggleCheckbox) {
             console.warn(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
+            alert(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
             return;
         }
 
         // 触发点击事件
         toggleCheckbox.click();
         console.log(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
-    }, 5000); // 100ms延迟确保DOM就绪
+
+         alert(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
+
+    }, 8000); // 100ms延迟确保DOM就绪
 }
 function toggleGlobalRegexState(regexId) {
     // 校验全局正则数组是否存在
@@ -275,7 +282,7 @@ $(function () {
 
               const targetRegexName = "状态栏美化"; // 替换为你的正则脚本名称
                 const targetRegexId = findGlobalRegexIdByName(targetRegexName);
-                
+                alert(targetRegexId)
                 if (targetRegexId) {
                     // 2. 模拟点击开关（切换状态）
                     simulateRegexToggle(targetRegexId);

--- a/index.js
+++ b/index.js
@@ -8,12 +8,8 @@ import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock } f
 import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
-import { addCopyToCodeBlocks } from "../../../../script.js"; 
-// 导入必要的变量和函数（如果未导入）
-import { this_chid, characters } from "../../../../script.js";
-// 假设Regex插件的核心处理函数在engine.js中，路径需根据实际情况调整
-import { runRegexScript } from "../../../extensions/regex/engine.js";
-
+// 补充导入禁用和启用扩展的函数
+import { extension_settings, getContext, enableExtension, disableExtension } from "../../../extensions.js";
 // 扩展名称和路径
 const extensionName = "st-image-auto-generation";
 // /scripts/extensions/third-party
@@ -200,33 +196,6 @@ $(function () {
         });
     })();
 });
-
-
-// 新增：重新应用所有启用的正则脚本到指定消息
-function reapplyRegexToMessage(message, messageIndex) {
-    try {
-        // 获取所有需要应用的正则脚本（全局+角色范围）
-        const regexScripts = [
-            // 全局正则脚本（过滤已禁用的）
-            ...(extension_settings.regex || []).filter(script => !script.disabled),
-            // 角色范围正则脚本（过滤已禁用的）
-            ...(characters[this_chid]?.data?.extensions?.regex_scripts || []).filter(script => !script.disabled)
-        ];
-
-        // 对当前消息应用每个正则脚本
-        regexScripts.forEach(script => {
-            // 调用Regex插件的核心处理函数（需与插件实现匹配）
-            // 注意：runRegexScript的参数可能需要调整，参考Regex插件的实际实现
-            runRegexScript(script, message, messageIndex);
-        });
-
-        // 再次更新消息UI，显示正则处理后的结果（包括状态栏）
-        updateMessageBlock(messageIndex, message);
-        console.log(`[${extensionName}] 已重新应用正则到消息，状态栏应正常显示`);
-    } catch (error) {
-        console.error(`[${extensionName}] 重新应用正则失败:`, error);
-    }
-}
 // 获取消息角色
 function getMesRole() {
     // 确保对象路径存在
@@ -337,12 +306,8 @@ async function handleIncomingMessage() {
                 }
 
                 // 获取消息元素用于稍后更新
-                //const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
-// 关键：提前定义messageId（在所有使用它的地方之前）
-const messageId = context.chat.length - 1; 
+                const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
 
-// 用定义好的messageId获取消息元素
-const messageElement = $(`.mes[mesid="${messageId}"]`);
                 // 处理每个匹配的图片标签
                 for (let i = 0; i < matches.length; i++) {
                     const prompt = matches[i];
@@ -370,25 +335,28 @@ const messageElement = $(`.mes[mesid="${messageId}"]`);
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                                   // Find the original image tag in the message
-                            const originalTag = message.mes.match(imgTagRegex)[0];
-                            // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" >`;
-                            message.mes = message.mes.replace(originalTag, newImageTag);
+                            // 找到消息中的原始图片标签并替换
+        const originalTag = message.mes.match(imgTagRegex)[0];
+        const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
+        message.mes = message.mes.replace(originalTag, newImageTag);
 
-                            // Update the message display using updateMessageBlock
-                            updateMessageBlock(context.chat.length - 1, message);
+        // 更新消息显示
+        updateMessageBlock(context.chat.length - 1, message);
 
-        // 3. 主动触发Regex插件重新处理当前消息，修复状态栏正则
-        reapplyRegexToMessage(message, context.chat.length - 1);
+        // 关键修复：重新触发正则插件以处理状态栏
+        // 1. 先禁用正则插件
+        await disableExtension('regex', false);
+        // 2. 短暂延迟确保禁用生效
+        await new Promise(resolve => setTimeout(resolve, 100));
+        // 3. 重新启用正则插件，使其重新处理所有消息
+        await enableExtension('regex', false);
 
-                            // Save the chat
-                            await context.saveChat();
+        // 保存聊天记录
+        await context.saveChat();
                         }
                     }
 
                 }
- 
                 toastr.success(`${matches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);

--- a/index.js
+++ b/index.js
@@ -341,7 +341,11 @@ async function handleIncomingMessage() {
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock
-                            updateMessageBlock(context.chat.length - 1, message);
+                            //updateMessageBlock(context.chat.length - 1, message);
+                                 // 2. 关键：用 appendMediaToMessage 触发格式重渲染
+                    // 该函数会自动解析 message.mes 的 Markdown（包括代码块）
+        const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
+        appendMediaToMessage(message, messageElement); // 复用原生函数，避免自己解析
 
                             // Save the chat
                             await context.saveChat();

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock } f
 import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
-import { getRegexedString, regex_placement } from '../../../extensions/regex/engine.js';
 
 // 扩展名称和路径
 const extensionName = "st-image-auto-generation";
@@ -102,7 +101,7 @@ async function createSettings(settingsHtml) {
         saveSettingsDebounced();
     });
 
-    // 添加提示词注入设置的事件 处理
+    // 添加提示词注入设置的事件处理
     $('#prompt_injection_enabled').on('change', function () {
         extension_settings[extensionName].promptInjection.enabled = $(this).prop('checked');
         saveSettingsDebounced();
@@ -194,76 +193,8 @@ $(function () {
                 updateUI();
             }, 200);
         });
-     
-        alert(findGlobalRegexIdByName('状态栏美化'))
-
- 
-toggleGlobalRegexState(findGlobalRegexIdByName('状态栏美化'))
-        
-        
     })();
 });
-
-function toggleGlobalRegexState(regexId) {
-    // 校验全局正则数组是否存在
-    if (!Array.isArray(extension_settings.regex)) {
-        console.warn('全局正则脚本数组不存在');
-        return false;
-    }
-
-    // 根据ID查找目标正则脚本
-    const targetScript = extension_settings.regex.find(script => script.id === regexId);
-    if (!targetScript) {
-        console.warn(`未找到ID为 ${regexId} 的全局正则脚本`);
-        return false;
-    }
-
-    // 取反当前状态（disabled为true表示禁用，取反后启用，反之亦然）
-    const originalState = targetScript.disabled;
-    targetScript.disabled = !originalState;
-
-    // 保存设置（延迟保存避免频繁操作）
-    saveSettingsDebounced();
-
-    // 输出状态变更信息
-    console.log(`全局正则脚本 ${regexId} 已${targetScript.disabled ? '禁用' : '启用'}`);
-    return true;
-}
-function findGlobalRegexIdByName(scriptName) {
-    // 处理输入名称（统一小写+去空格，避免匹配差异）
-    const targetName = scriptName.toLowerCase().trim();
-    
-    // 校验全局正则数组是否存在
-    if (!Array.isArray(extension_settings.regex)) {
-        console.warn('全局正则脚本数组不存在');
-        return null;
-    }
-    
-    // 遍历全局正则数组，匹配名称
-    const matchedScript = extension_settings.regex.find(script => {
-        // 脚本名称可能为undefined，需先判断
-        if (typeof script.scriptName !== 'string') return false;
-        // 统一处理脚本名称后比较
-        return script.scriptName.toLowerCase().trim() === targetName;
-    });
-    
-    // 返回找到的ID或null
-    return matchedScript ? matchedScript.id : null;
-}
-function toggleGlobalRegex(regexId, enable) {
-    // 查找对应ID的全局正则脚本
-    const targetScript = extension_settings.regex?.find(script => script.id === regexId);
-    if (!targetScript) {
-        console.warn(`未找到ID为 ${regexId} 的全局正则脚本`);
-        return false;
-    }
-    // 修改disabled属性（enable为true时，disabled设为false，反之亦然）
-    targetScript.disabled = !enable;
-    // 保存设置（延迟保存，避免频繁操作）
-    saveSettingsDebounced();
-    console.log(`全局正则脚本 ${regexId} 已${enable ? '启用' : '禁用'}`);
-    return true;
-}
 // 获取消息角色
 function getMesRole() {
     // 确保对象路径存在
@@ -419,29 +350,18 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // 1. 替换原始标签为img标签
-        const newImageTag = `<img src="${imageUrl}" promot="${prompt}">`;
-        let modifiedMes = message.mes.replace(originalTag, newImageTag);
-
-        // 3. 更新消息内容
-        message.mes = modifiedMes;
-
-        // 4. 更新UI显示
-        updateMessageBlock(context.chat.length - 1, message);
-
-        // 5. 保存聊天记录
-        await context.saveChat();
-
-
-
+                            // 直接使用预存的原始标签进行替换
+                            const newImageTag = `<img src="${imageUrl}"  promot="${prompt}">`;
+                            message.mes = message.mes.replace(originalTag, newImageTag);
+                            // 更新消息显示
+                            updateMessageBlock(context.chat.length - 1, message);
+                            // 保存聊天
+                            await context.saveChat();
                         }
                     }
                 }
-                  toastr.success("开始正则触发")
-        // 2. 手动触发正则重新处理（关键步骤）
-        // 场景指定为AI输出，确保所有AI相关的正则脚本生效
-        modifiedMes = getRegexedString(modifiedMes, regex_placement.AI_OUTPUT);
-  toastr.success("结束正则触发")
+             alert(findGlobalRegexIdByName('状态栏美化'))
+        toggleGlobalRegexState(findGlobalRegexIdByName('状态栏美化'))
                 toastr.success(`${tagMatches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);
@@ -450,3 +370,5 @@ async function handleIncomingMessage() {
         }, 0); // 防阻塞UI渲染
     }
 }
+
+

--- a/index.js
+++ b/index.js
@@ -10,11 +10,10 @@ import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
 import { addCopyToCodeBlocks } from "../../../../script.js"; 
 import { 
-    getRegexedString, 
-    regex_placement, 
-    messageFormatting, 
-    addCopyToCodeBlocks,
-    updateMessageBlock
+    updateMessageBlock, 
+    addCopyToCodeBlocks, 
+    eventSource, 
+    event_types  
 } from "../../../../script.js";
 
 // 扩展名称和路径
@@ -342,7 +341,7 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // 1. 匹配并替换 <pic> 标签（之前的逻辑不变）
+            // 1. 匹配并替换 <pic> 标签（逻辑不变）
         const matches = [...message.mes.matchAll(imgTagRegex)];
         const originalMatch = matches[0];
         if (!originalMatch) return;
@@ -351,24 +350,23 @@ async function handleIncomingMessage() {
         const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" class="st-generated-image" title="${prompt}" alt="${prompt}" />`;
         message.mes = message.mes.replace(originalTag, newImageTag);
 
-        // 2. 关键：手动调用正则插件的核心函数，处理状态栏正则
-        // 注意：placement 需对应状态栏正则的生效位置（通常是 AI 输出，即 regex_placement.AI_OUTPUT）
-        const placement = regex_placement.AI_OUTPUT; // 从 script.js 导入 regex_placement
-        message.mes = getRegexedString(message.mes, placement, {
-            characterOverride: message.name, // 传递角色名（插件可能需要）
-            isMarkdown: true,
-        });
-
-        // 3. 清除 display_text 缓存，确保 ST 用处理后的 mes
+        // 2. 清除 display_text 缓存（避免 ST 用旧内容）
         if (message.extra) {
             message.extra.display_text = null;
         }
 
-        // 4. 更新 UI（触发渲染）
+        // 3. 更新消息 UI（触发基础渲染）
         const messageId = context.chat.length - 1;
         updateMessageBlock(messageId, message);
 
-        // 5. 补充代码块功能
+        // 4. 关键：触发 ST 消息更新事件，通知正则插件重新处理
+        // （模拟“手动开关插件”的效果，正则插件会监听这个事件）
+        eventSource.emit(event_types.MESSAGE_MODIFIED, {
+            messageId: messageId,
+            message: message
+        });
+
+        // 5. 补充代码块功能（确保复制按钮生效）
         const messageElement = $(`.mes[mesid="${messageId}"]`);
         addCopyToCodeBlocks(messageElement);
 

--- a/index.js
+++ b/index.js
@@ -279,6 +279,7 @@ async function handleIncomingMessage() {
     // 使用正则表达式匹配
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
     // 保存完整匹配结果（包含完整标签和捕获组）
+    alert(imgTagRegex)
     let matches;
     if (imgTagRegex.global) {
         matches = [...message.mes.matchAll(imgTagRegex)]; // 全局匹配时获取所有完整match对象
@@ -286,6 +287,7 @@ async function handleIncomingMessage() {
         const singleMatch = message.mes.match(imgTagRegex);
         matches = singleMatch ? [singleMatch] : []; // 非全局匹配时处理单个结果
     }
+    alert(matches)
 
     console.log(`[${extensionName}] 匹配到的完整标签:`, matches.map(m => m[0]));
     if (matches.length > 0) {

--- a/index.js
+++ b/index.js
@@ -194,6 +194,8 @@ $(function () {
                 updateUI();
             }, 200);
         });
+     
+        alert(extension_settings.regex.map(script => script.id))
     })();
 });
 // 获取消息角色

--- a/index.js
+++ b/index.js
@@ -353,12 +353,26 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // 直接使用预存的原始标签进行替换
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}">`;
-                            message.mes = message.mes.replace(originalTag, newImageTag);
-                            // 更新消息显示
-                            updateMessageBlock(context.chat.length - 1, message);
-                            // 保存聊天
+                            // 1. 创建新的img元素（保留提示词作为标题和alt）
+                            const imgElement = $(`<img src="${imageUrl}" title="${prompt}" alt="${prompt}" class="auto-generated-image">`);
+                            
+                            // 2. 找到消息DOM中对应的<pic>标签节点
+                            // 注意：需要从原始标签文本创建选择器（转义特殊字符）
+                            const escapedTag = originalTag.replace(/[!"#$%&'()*+,.\/:;<=>?@[\]^_`{|}~]/g, '\\$&');
+                            const picElement = messageElement.find(`:contains("${escapedTag}")`).filter(function() {
+                                // 精确匹配包含原始标签的文本节点的父元素
+                                return $(this).html().includes(originalTag);
+                            });
+
+                            if (picElement.length) {
+                                // 3. 直接替换DOM中的<pic>标签为img元素（不影响其他HTML）
+                                picElement.html(function(index, html) {
+                                    return html.replace(originalTag, imgElement.prop('outerHTML'));
+                                });
+                            }
+
+                            // 4. 同步更新message.mes（确保保存时内容正确，不影响已渲染DOM）
+                            message.mes = message.mes.replace(originalTag, imgElement.prop('outerHTML'));
                             await context.saveChat();
                         }
                     }

--- a/index.js
+++ b/index.js
@@ -355,10 +355,6 @@ async function handleIncomingMessage() {
         const newImageTag = `<img src="${imageUrl}" promot="${prompt}">`;
         let modifiedMes = message.mes.replace(originalTag, newImageTag);
 
-        // 2. 手动触发正则重新处理（关键步骤）
-        // 场景指定为AI输出，确保所有AI相关的正则脚本生效
-        modifiedMes = getRegexedString(modifiedMes, regex_placement.AI_OUTPUT);
-
         // 3. 更新消息内容
         message.mes = modifiedMes;
 
@@ -367,6 +363,10 @@ async function handleIncomingMessage() {
 
         // 5. 保存聊天记录
         await context.saveChat();
+
+        // 2. 手动触发正则重新处理（关键步骤）
+        // 场景指定为AI输出，确保所有AI相关的正则脚本生效
+        modifiedMes = getRegexedString(modifiedMes, regex_placement.AI_OUTPUT);
 
         // 6. 可选：触发消息更新事件，确保其他组件同步
         // eventSource.dispatchEvent(new CustomEvent(event_types.MESSAGE_UPDATED, {

--- a/index.js
+++ b/index.js
@@ -252,12 +252,7 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventDa
 });
 
 // 监听消息接收事件
-//eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
-eventSource.on(event_types.MESSAGE_RECEIVED, () => setTimeout(handleIncomingMessage, 500));
-
-
-
-
+eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
 async function handleIncomingMessage() {
     // 确保设置对象存在
     if (!extension_settings[extensionName] ||
@@ -280,23 +275,12 @@ async function handleIncomingMessage() {
         return;
     }
 
+    // 使用正则表达式search
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
- // 封装匹配逻辑为函数，便于重复调用
- const getMatches = (content, regex) => {
-     return regex.global 
-         ? [...content.matchAll(regex)].map(match => match[1]) 
-         : [content.match(regex)?.[1]].filter(Boolean); // 增加?.和filter避免匹配失败时的undefined
- };
- let matches = getMatches(message.mes, imgTagRegex);
- // 首次匹配为空时，延迟500ms重试一次
- if (matches.length === 0) {
-	 alert(0)
-     await new Promise(resolve => setTimeout(resolve, 500)); // 阻塞等待500ms，不影响外层异步逻辑
-     matches = getMatches(message.mes, imgTagRegex); // 重试匹配，覆盖原matches值
- }
- console.log(imgTagRegex, matches);
-		 alert(matches.length)
-	if (matches.length > 0) {
+    // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
+    let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
+    console.log(imgTagRegex, matches)
+    if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {
             try {
@@ -353,7 +337,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}"> current_datetime='202510052258'`;
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt},dmzz">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -216,71 +216,6 @@ function getMesRole() {
     }
 }
 
-/**
- * 根据名称查找全局正则脚本的ID
- * @param {string} scriptName - 要查找的正则脚本名称
- * @returns {string|null} 匹配的全局正则ID，未找到则返回null
- */
-function findGlobalRegexIdByName(scriptName) {
-    // 处理输入名称（统一小写+去空格，避免匹配差异）
-    const targetName = scriptName.toLowerCase().trim();
-    
-    // 校验全局正则数组是否存在
-    if (!Array.isArray(extension_settings.regex)) {
-        console.warn('全局正则脚本数组不存在');
-        return null;
-    }
-    
-    // 遍历全局正则数组，匹配名称
-    const matchedScript = extension_settings.regex.find(script => {
-        // 脚本名称可能为undefined，需先判断
-        if (typeof script.scriptName !== 'string') return false;
-        // 统一处理脚本名称后比较
-        return script.scriptName.toLowerCase().trim() === targetName;
-    });
-    
-    // 返回找到的ID或null
-    return matchedScript ? matchedScript.id : null;
-}
-function simulateRegexToggle(regexId) {
-    // 延迟执行，确保DOM已渲染（SillyTavern消息渲染可能有延迟）
-    setTimeout(() => {
-        // 直接通过ID定位正则容器（基于用户提供的DOM结构）
-        const scriptContainer = document.getElementById(regexId);
-        if (!scriptContainer) {
-                          //  alert(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`)
-
-            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`);
-            return;
-        }
-
-        // 验证容器类型
-        if (!scriptContainer.classList.contains('regex-script-label')) {
-            console.warn(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
-            //alert(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
-            return;
-        }
-
-        // 查找开关按钮（基于用户提供的class="disable_regex"）
-        const toggleCheckbox = scriptContainer.querySelector('.disable_regex');
-        if (!toggleCheckbox) {
-            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
-            //alert(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
-            return;
-        }
-
-        // 触发点击事件
-        toggleCheckbox.click();
-        console.log(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
-
-        // alert(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
-        toastr.success(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
-
-    }, 200); // 100ms延迟确保DOM就绪
-}
-
-
-
 // 监听CHAT_COMPLETION_PROMPT_READY事件以注入提示词
 eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventData) {
     try {
@@ -317,14 +252,7 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventDa
 });
 
 // 监听消息接收事件
-//eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
-// 监听消息接收事件 - 立即捕获触发时的上下文，再延迟执行
- eventSource.on(event_types.MESSAGE_RECEIVED, () => {
-     // 事件触发时立即保存当前聊天索引（快照）
-     //const targetMessageIndex = context.chat.length - 1; 
-     setTimeout(() => handleIncomingMessage, 500);
- });
-
+eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
 async function handleIncomingMessage() {
     // 确保设置对象存在
     if (!extension_settings[extensionName] ||
@@ -347,14 +275,23 @@ async function handleIncomingMessage() {
         return;
     }
 
-    // 使用正则表达式search
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-	alert(imgTagRegex)
-    // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-    let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
-    alert(imgTagRegex, matches)
-	alert(matches.length)
-    if (matches.length > 0) {
+ // 封装匹配逻辑为函数，便于重复调用
+ const getMatches = (content, regex) => {
+     return regex.global 
+         ? [...content.matchAll(regex)].map(match => match[1]) 
+         : [content.match(regex)?.[1]].filter(Boolean); // 增加?.和filter避免匹配失败时的undefined
+ };
+ let matches = getMatches(message.mes, imgTagRegex);
+ // 首次匹配为空时，延迟500ms重试一次
+ if (matches.length === 0) {
+	 alert(0)
+     await new Promise(resolve => setTimeout(resolve, 500)); // 阻塞等待500ms，不影响外层异步逻辑
+     matches = getMatches(message.mes, imgTagRegex); // 重试匹配，覆盖原matches值
+ }
+ console.log(imgTagRegex, matches);
+		 alert(matches.length)
+	if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {
             try {
@@ -411,7 +348,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" current_datetime='202510052258'>`;
+                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock
@@ -423,18 +360,6 @@ async function handleIncomingMessage() {
                     }
 
                 }
-				
-				 // 1. 先通过正则名称查找ID（这里假设要操作的正则名称是"状态栏美化"，可根据实际修改）
-                const targetRegexName = "状态栏美化"; // 替换为你的正则脚本名称
-                const targetRegexId = findGlobalRegexIdByName(targetRegexName);
-                
-                if (targetRegexId) {
-                    // 2. 模拟点击开关（切换状态）
-                    simulateRegexToggle(targetRegexId);
-                } else {
-                    alert(`[${extensionName}] 未找到名称为"${targetRegexName}"的全局正则脚本`);
-                }
-				
                 toastr.success(`${matches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);

--- a/index.js
+++ b/index.js
@@ -369,12 +369,12 @@ async function handleIncomingMessage() {
         await context.saveChat();
 
         // 6. 可选：触发消息更新事件，确保其他组件同步
-        eventSource.dispatchEvent(new CustomEvent(event_types.MESSAGE_UPDATED, {
-            detail: {
-                messageId: context.chat.length - 1,
-                message: message
-            }
-        }));
+        // eventSource.dispatchEvent(new CustomEvent(event_types.MESSAGE_UPDATED, {
+        //     detail: {
+        //         messageId: context.chat.length - 1,
+        //         message: message
+        //     }
+        // }));
                         }
                     }
                 }

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function simulateRegexToggle(regexId) {
         // 直接通过ID定位正则容器（基于用户提供的DOM结构）
         const scriptContainer = document.getElementById(regexId);
         if (!scriptContainer) {
-                            alert(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`)
+                          //  alert(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`)
 
             console.warn(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`);
             return;
@@ -93,7 +93,7 @@ function simulateRegexToggle(regexId) {
         // 验证容器类型
         if (!scriptContainer.classList.contains('regex-script-label')) {
             console.warn(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
-            alert(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
+            //alert(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
             return;
         }
 
@@ -101,7 +101,7 @@ function simulateRegexToggle(regexId) {
         const toggleCheckbox = scriptContainer.querySelector('.disable_regex');
         if (!toggleCheckbox) {
             console.warn(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
-            alert(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
+            //alert(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
             return;
         }
 
@@ -109,9 +109,9 @@ function simulateRegexToggle(regexId) {
         toggleCheckbox.click();
         console.log(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
 
-         alert(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
+        // alert(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
 
-    }, 8000); // 100ms延迟确保DOM就绪
+    }, 200); // 100ms延迟确保DOM就绪
 }
 function toggleGlobalRegexState(regexId) {
     // 校验全局正则数组是否存在
@@ -279,17 +279,6 @@ $(function () {
             }, 200);
         });
 
-
-              const targetRegexName = "状态栏美化"; // 替换为你的正则脚本名称
-                const targetRegexId = findGlobalRegexIdByName(targetRegexName);
-                alert(targetRegexId)
-                if (targetRegexId) {
-                    // 2. 模拟点击开关（切换状态）
-                    simulateRegexToggle(targetRegexId);
-                } else {
-                    console.warn(`[${extensionName}] 未找到名称为"${targetRegexName}"的全局正则脚本`);
-                }
-        
     })();
 });
 // 获取消息角色
@@ -466,7 +455,7 @@ async function handleIncomingMessage() {
                     // 2. 模拟点击开关（切换状态）
                     simulateRegexToggle(targetRegexId);
                 } else {
-                    console.warn(`[${extensionName}] 未找到名称为"${targetRegexName}"的全局正则脚本`);
+                    alert(`[${extensionName}] 未找到名称为"${targetRegexName}"的全局正则脚本`);
                 }
                 
                 toastr.success(`${tagMatches.length} images generated successfully`);

--- a/index.js
+++ b/index.js
@@ -252,7 +252,12 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventDa
 });
 
 // 监听消息接收事件
-eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
+//eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
+eventSource.on(event_types.MESSAGE_RECEIVED, () => setTimeout(handleIncomingMessage, 500));
+
+
+
+
 async function handleIncomingMessage() {
     // 确保设置对象存在
     if (!extension_settings[extensionName] ||

--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
+                            const newImageTag = `<img src="${imageUrl}" promot="${prompt}">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -343,10 +343,7 @@ async function handleIncomingMessage() {
         const prompt = originalMatch[1]; 
 
         // 步骤2：构造符合 ST 渲染规范的 <img> 标签（加 class 适配样式）
-        const newImageTag = `<img 
-            src="${imageUrl}" 
-            prompt="${prompt}" 
-        />`;
+        const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" />`;
 
         // 步骤3：修改 message.mes（替换 <pic> 为 <img>）
         message.mes = message.mes.replace(originalTag, newImageTag);

--- a/index.js
+++ b/index.js
@@ -287,6 +287,8 @@ async function handleIncomingMessage() {
         matches = singleMatch ? [singleMatch] : []; // 非全局匹配时处理单个结果
     }
   //alert(matches)
+                    toastr.success(`开始生成图片`);
+
     console.log(`[${extensionName}] 匹配到的完整标签:`, matches.map(m => m[0]));
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来

--- a/index.js
+++ b/index.js
@@ -317,7 +317,14 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventDa
 });
 
 // 监听消息接收事件
-eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
+//eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
+// 监听消息接收事件 - 立即捕获触发时的上下文，再延迟执行
+ eventSource.on(event_types.MESSAGE_RECEIVED, () => {
+     // 事件触发时立即保存当前聊天索引（快照）
+     //const targetMessageIndex = context.chat.length - 1; 
+     setTimeout(() => handleIncomingMessage(), 500);
+ });
+
 async function handleIncomingMessage() {
     // 确保设置对象存在
     if (!extension_settings[extensionName] ||

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ import { saveSettingsDebounced, eventSource, event_types, updateMessageBlock } f
 import { appendMediaToMessage } from "../../../../script.js";
 import { regexFromString } from '../../../utils.js';
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
-
+import { addCopyToCodeBlocks } from "../../../../script.js"; 
 // 扩展名称和路径
 const extensionName = "st-image-auto-generation";
 // /scripts/extensions/third-party
@@ -334,21 +334,42 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // Find the original image tag in the message
-                            const originalTag = message.mes.match(imgTagRegex)[0];
-                            // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
-                            message.mes = message.mes.replace(originalTag, newImageTag);
+                            // 步骤1：匹配原始 <pic> 标签（注意：用 matchAll 避免多次匹配时的索引偏移）
+        const matches = [...message.mes.matchAll(imgTagRegex)];
+        // 取第一个匹配的标签（若需处理多标签，可循环）
+        const originalMatch = matches[0];
+        if (!originalMatch) return; // 无匹配标签则退出
+        const originalTag = originalMatch[0]; // 完整的 <pic> 标签
+        const prompt = originalMatch[1]; // 提取的 prompt
 
-                            // Update the message display using updateMessageBlock
-                            //updateMessageBlock(context.chat.length - 1, message);
-                                 // 2. 关键：用 appendMediaToMessage 触发格式重渲染
-                    // 该函数会自动解析 message.mes 的 Markdown（包括代码块）
+        // 步骤2：构造符合 ST 渲染规范的 <img> 标签（加 class 适配样式）
+        const newImageTag = `<img 
+            src="${imageUrl}" 
+            prompt="${prompt}" 
+            class="st-generated-image" 
+            alt="Auto-generated image: ${prompt}"  // 加 alt 适配无障碍
+            title="${prompt}"  // 保留 prompt 到 title
+        />`;
+
+        // 步骤3：修改 message.mes（替换 <pic> 为 <img>）
+        message.mes = message.mes.replace(originalTag, newImageTag);
+
+        // 步骤4：关键！删除 extra.display_text（避免 updateMessageBlock 优先用旧文本）
+        if (message.extra && message.extra.display_text) {
+            delete message.extra.display_text;
+            console.log('[ST-Image-Auto-Gen] Deleted old display_text to force Markdown reparse');
+        }
+
+        // 步骤5：调用 ST 原生 updateMessageBlock，触发全量渲染
+        // 无需传 rerenderMessage，默认 true，会自动调用 messageFormatting 解析代码块
+        updateMessageBlock(context.chat.length - 1, message);
+
+        // 步骤6：保存聊天记录（同步修改后的 mes）
+        await context.saveChat();
+
+        // 步骤7：额外保障：手动调用 addCopyToCodeBlocks（确保代码块复制按钮正常）
         const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
-        appendMediaToMessage(message, messageElement); // 复用原生函数，避免自己解析
-
-                            // Save the chat
-                            await context.saveChat();
+        addCopyToCodeBlocks(messageElement);
                         }
                     }
 

--- a/index.js
+++ b/index.js
@@ -363,10 +363,11 @@ async function handleIncomingMessage() {
 
         // 5. 保存聊天记录
         await context.saveChat();
-
+  toastr.success("开始正则触发")
         // 2. 手动触发正则重新处理（关键步骤）
         // 场景指定为AI输出，确保所有AI相关的正则脚本生效
         modifiedMes = getRegexedString(modifiedMes, regex_placement.AI_OUTPUT);
+  toastr.success("结束正则触发")
 
         // 6. 可选：触发消息更新事件，确保其他组件同步
         // eventSource.dispatchEvent(new CustomEvent(event_types.MESSAGE_UPDATED, {

--- a/index.js
+++ b/index.js
@@ -402,7 +402,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" datetime='202510052258'>`;
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" current_datetime='202510052258'>`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -52,7 +52,32 @@ function updateUI() {
         $('#prompt_injection_depth').val(extension_settings[extensionName].promptInjection.depth);
     }
 }
-
+/**
+ * 根据名称查找全局正则脚本的ID
+ * @param {string} scriptName - 要查找的正则脚本名称
+ * @returns {string|null} 匹配的全局正则ID，未找到则返回null
+ */
+function findGlobalRegexIdByName(scriptName) {
+    // 处理输入名称（统一小写+去空格，避免匹配差异）
+    const targetName = scriptName.toLowerCase().trim();
+    
+    // 校验全局正则数组是否存在
+    if (!Array.isArray(extension_settings.regex)) {
+        console.warn('全局正则脚本数组不存在');
+        return null;
+    }
+    
+    // 遍历全局正则数组，匹配名称
+    const matchedScript = extension_settings.regex.find(script => {
+        // 脚本名称可能为undefined，需先判断
+        if (typeof script.scriptName !== 'string') return false;
+        // 统一处理脚本名称后比较
+        return script.scriptName.toLowerCase().trim() === targetName;
+    });
+    
+    // 返回找到的ID或null
+    return matchedScript ? matchedScript.id : null;
+}
 // 加载设置
 async function loadSettings() {
     extension_settings[extensionName] = extension_settings[extensionName] || {};
@@ -142,7 +167,36 @@ function onExtensionButtonClick() {
     if ($('#rm_extensions_block').hasClass('closedDrawer')) {
         extensionsDrawer.trigger('click');
     }
+/**
+ * 切换全局正则脚本的启用/禁用状态（取反当前状态）
+ * @param {string} regexId - 全局正则脚本的ID
+ * @returns {boolean} 操作是否成功（找到并切换状态）
+ */
+function toggleGlobalRegexState(regexId) {
+    // 校验全局正则数组是否存在
+    if (!Array.isArray(extension_settings.regex)) {
+        console.warn('全局正则脚本数组不存在');
+        return false;
+    }
 
+    // 根据ID查找目标正则脚本
+    const targetScript = extension_settings.regex.find(script => script.id === regexId);
+    if (!targetScript) {
+        console.warn(`未找到ID为 ${regexId} 的全局正则脚本`);
+        return false;
+    }
+
+    // 取反当前状态（disabled为true表示禁用，取反后启用，反之亦然）
+    const originalState = targetScript.disabled;
+    targetScript.disabled = !originalState;
+
+    // 保存设置（延迟保存避免频繁操作）
+    saveSettingsDebounced();
+
+    // 输出状态变更信息
+    console.log(`全局正则脚本 ${regexId} 已${targetScript.disabled ? '禁用' : '启用'}`);
+    return true;
+}
     // 等待抽屉打开后滚动到我们的设置容器
     setTimeout(() => {
         // 找到我们的设置容器

--- a/index.js
+++ b/index.js
@@ -279,7 +279,6 @@ async function handleIncomingMessage() {
     // 使用正则表达式匹配
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
     // 保存完整匹配结果（包含完整标签和捕获组）
-    alert(imgTagRegex)
     let matches;
     if (imgTagRegex.global) {
         matches = [...message.mes.matchAll(imgTagRegex)]; // 全局匹配时获取所有完整match对象
@@ -287,7 +286,6 @@ async function handleIncomingMessage() {
         const singleMatch = message.mes.match(imgTagRegex);
         matches = singleMatch ? [singleMatch] : []; // 非全局匹配时处理单个结果
     }
-    alert(matches)
 
     console.log(`[${extensionName}] 匹配到的完整标签:`, matches.map(m => m[0]));
     if (matches.length > 0) {

--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ async function handleIncomingMessage() {
 
                 // 获取消息元素用于稍后更新
                 const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
-
+                alert(matches.length)
                 // 处理每个匹配的图片标签
                 for (let i = 0; i < matches.length; i++) {
                     const prompt = matches[i];
@@ -335,7 +335,10 @@ async function handleIncomingMessage() {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
                             // Find the original image tag in the message
+                            alert(imgTagRegex)
                             const originalTag = message.mes.match(imgTagRegex)[0];
+                                            alert(originalTag)
+
                             // Replace it with an actual image tag
                             const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" >`;
                             message.mes = message.mes.replace(originalTag, newImageTag);

--- a/index.js
+++ b/index.js
@@ -78,6 +78,32 @@ function findGlobalRegexIdByName(scriptName) {
     // 返回找到的ID或null
     return matchedScript ? matchedScript.id : null;
 }
+
+function toggleGlobalRegexState(regexId) {
+    // 校验全局正则数组是否存在
+    if (!Array.isArray(extension_settings.regex)) {
+        console.warn('全局正则脚本数组不存在');
+        return false;
+    }
+
+    // 根据ID查找目标正则脚本
+    const targetScript = extension_settings.regex.find(script => script.id === regexId);
+    if (!targetScript) {
+        console.warn(`未找到ID为 ${regexId} 的全局正则脚本`);
+        return false;
+    }
+
+    // 取反当前状态（disabled为true表示禁用，取反后启用，反之亦然）
+    const originalState = targetScript.disabled;
+    targetScript.disabled = !originalState;
+
+    // 保存设置（延迟保存避免频繁操作）
+    saveSettingsDebounced();
+
+    // 输出状态变更信息
+    console.log(`全局正则脚本 ${regexId} 已${targetScript.disabled ? '禁用' : '启用'}`);
+    return true;
+}
 // 加载设置
 async function loadSettings() {
     extension_settings[extensionName] = extension_settings[extensionName] || {};
@@ -167,36 +193,7 @@ function onExtensionButtonClick() {
     if ($('#rm_extensions_block').hasClass('closedDrawer')) {
         extensionsDrawer.trigger('click');
     }
-/**
- * 切换全局正则脚本的启用/禁用状态（取反当前状态）
- * @param {string} regexId - 全局正则脚本的ID
- * @returns {boolean} 操作是否成功（找到并切换状态）
- */
-function toggleGlobalRegexState(regexId) {
-    // 校验全局正则数组是否存在
-    if (!Array.isArray(extension_settings.regex)) {
-        console.warn('全局正则脚本数组不存在');
-        return false;
-    }
 
-    // 根据ID查找目标正则脚本
-    const targetScript = extension_settings.regex.find(script => script.id === regexId);
-    if (!targetScript) {
-        console.warn(`未找到ID为 ${regexId} 的全局正则脚本`);
-        return false;
-    }
-
-    // 取反当前状态（disabled为true表示禁用，取反后启用，反之亦然）
-    const originalState = targetScript.disabled;
-    targetScript.disabled = !originalState;
-
-    // 保存设置（延迟保存避免频繁操作）
-    saveSettingsDebounced();
-
-    // 输出状态变更信息
-    console.log(`全局正则脚本 ${regexId} 已${targetScript.disabled ? '禁用' : '启用'}`);
-    return true;
-}
     // 等待抽屉打开后滚动到我们的设置容器
     setTimeout(() => {
         // 找到我们的设置容器
@@ -414,8 +411,8 @@ async function handleIncomingMessage() {
                         }
                     }
                 }
-             alert(findGlobalRegexIdByName('状态栏美化'))
-        toggleGlobalRegexState(findGlobalRegexIdByName('状态栏美化'))
+             alert(findGlobalRegexIdByName('状态栏美化'));
+        toggleGlobalRegexState(findGlobalRegexIdByName('状态栏美化'));
                 toastr.success(`${tagMatches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);

--- a/index.js
+++ b/index.js
@@ -52,92 +52,7 @@ function updateUI() {
         $('#prompt_injection_depth').val(extension_settings[extensionName].promptInjection.depth);
     }
 }
-/**
- * 根据名称查找全局正则脚本的ID
- * @param {string} scriptName - 要查找的正则脚本名称
- * @returns {string|null} 匹配的全局正则ID，未找到则返回null
- */
-function findGlobalRegexIdByName(scriptName) {
-    // 处理输入名称（统一小写+去空格，避免匹配差异）
-    const targetName = scriptName.toLowerCase().trim();
-    
-    // 校验全局正则数组是否存在
-    if (!Array.isArray(extension_settings.regex)) {
-        console.warn('全局正则脚本数组不存在');
-        return null;
-    }
-    
-    // 遍历全局正则数组，匹配名称
-    const matchedScript = extension_settings.regex.find(script => {
-        // 脚本名称可能为undefined，需先判断
-        if (typeof script.scriptName !== 'string') return false;
-        // 统一处理脚本名称后比较
-        return script.scriptName.toLowerCase().trim() === targetName;
-    });
-    
-    // 返回找到的ID或null
-    return matchedScript ? matchedScript.id : null;
-}
-function simulateRegexToggle(regexId) {
-    // 延迟执行，确保DOM已渲染（SillyTavern消息渲染可能有延迟）
-    setTimeout(() => {
-        // 直接通过ID定位正则容器（基于用户提供的DOM结构）
-        const scriptContainer = document.getElementById(regexId);
-        if (!scriptContainer) {
-                          //  alert(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`)
 
-            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`);
-            return;
-        }
-
-        // 验证容器类型
-        if (!scriptContainer.classList.contains('regex-script-label')) {
-            console.warn(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
-            //alert(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
-            return;
-        }
-
-        // 查找开关按钮（基于用户提供的class="disable_regex"）
-        const toggleCheckbox = scriptContainer.querySelector('.disable_regex');
-        if (!toggleCheckbox) {
-            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
-            //alert(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
-            return;
-        }
-
-        // 触发点击事件
-        toggleCheckbox.click();
-        console.log(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
-
-        // alert(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
-
-    }, 200); // 100ms延迟确保DOM就绪
-}
-function toggleGlobalRegexState(regexId) {
-    // 校验全局正则数组是否存在
-    if (!Array.isArray(extension_settings.regex)) {
-        console.warn('全局正则脚本数组不存在');
-        return false;
-    }
-
-    // 根据ID查找目标正则脚本
-    const targetScript = extension_settings.regex.find(script => script.id === regexId);
-    if (!targetScript) {
-        console.warn(`未找到ID为 ${regexId} 的全局正则脚本`);
-        return false;
-    }
-
-    // 取反当前状态（disabled为true表示禁用，取反后启用，反之亦然）
-    const originalState = targetScript.disabled;
-    targetScript.disabled = !originalState;
-
-    // 保存设置（延迟保存避免频繁操作）
-    saveSettingsDebounced();
-
-    // 输出状态变更信息
-    console.log(`全局正则脚本 ${regexId} 已${targetScript.disabled ? '禁用' : '启用'}`);
-    return true;
-}
 // 加载设置
 async function loadSettings() {
     extension_settings[extensionName] = extension_settings[extensionName] || {};
@@ -278,7 +193,6 @@ $(function () {
                 updateUI();
             }, 200);
         });
-
     })();
 });
 // 获取消息角色
@@ -301,6 +215,71 @@ function getMesRole() {
             return 'system';
     }
 }
+
+/**
+ * 根据名称查找全局正则脚本的ID
+ * @param {string} scriptName - 要查找的正则脚本名称
+ * @returns {string|null} 匹配的全局正则ID，未找到则返回null
+ */
+function findGlobalRegexIdByName(scriptName) {
+    // 处理输入名称（统一小写+去空格，避免匹配差异）
+    const targetName = scriptName.toLowerCase().trim();
+    
+    // 校验全局正则数组是否存在
+    if (!Array.isArray(extension_settings.regex)) {
+        console.warn('全局正则脚本数组不存在');
+        return null;
+    }
+    
+    // 遍历全局正则数组，匹配名称
+    const matchedScript = extension_settings.regex.find(script => {
+        // 脚本名称可能为undefined，需先判断
+        if (typeof script.scriptName !== 'string') return false;
+        // 统一处理脚本名称后比较
+        return script.scriptName.toLowerCase().trim() === targetName;
+    });
+    
+    // 返回找到的ID或null
+    return matchedScript ? matchedScript.id : null;
+}
+function simulateRegexToggle(regexId) {
+    // 延迟执行，确保DOM已渲染（SillyTavern消息渲染可能有延迟）
+    setTimeout(() => {
+        // 直接通过ID定位正则容器（基于用户提供的DOM结构）
+        const scriptContainer = document.getElementById(regexId);
+        if (!scriptContainer) {
+                          //  alert(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`)
+
+            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则脚本容器`);
+            return;
+        }
+
+        // 验证容器类型
+        if (!scriptContainer.classList.contains('regex-script-label')) {
+            console.warn(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
+            //alert(`[${extensionName}] ID为${regexId}的元素不是正则脚本容器`);
+            return;
+        }
+
+        // 查找开关按钮（基于用户提供的class="disable_regex"）
+        const toggleCheckbox = scriptContainer.querySelector('.disable_regex');
+        if (!toggleCheckbox) {
+            console.warn(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
+            //alert(`[${extensionName}] 未找到ID为${regexId}的正则开关`);
+            return;
+        }
+
+        // 触发点击事件
+        toggleCheckbox.click();
+        console.log(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
+
+        // alert(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
+        toastr.success(`[${extensionName}] 已模拟点击正则脚本${regexId}的开关`);
+
+    }, 200); // 100ms延迟确保DOM就绪
+}
+
+
 
 // 监听CHAT_COMPLETION_PROMPT_READY事件以注入提示词
 eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventData) {
@@ -336,6 +315,7 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventDa
         toastr.error(`提示词注入错误: ${error}`);
     }
 });
+
 // 监听消息接收事件
 eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
 async function handleIncomingMessage() {
@@ -360,43 +340,18 @@ async function handleIncomingMessage() {
         return;
     }
 
-    // 使用正则表达式一次性匹配所有结果
+    // 使用正则表达式search
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-    // 存储所有匹配的标签和提示词（完整标签+捕获组内容）
-    const tagMatches = [];
-    
-    // 一次性获取所有匹配项
-    if (imgTagRegex.global) {
-        // 全局匹配时使用matchAll获取所有结果
-        const allMatches = message.mes.matchAll(imgTagRegex);
-        for (const match of allMatches) {
-            // match[0]是完整标签，match[1]是提示词（第一个捕获组）
-            tagMatches.push({
-                tag: match[0],
-                prompt: match[1]
-            });
-        }
-    } else {
-        // 非全局匹配时只取第一个结果
-        const singleMatch = message.mes.match(imgTagRegex);
-        if (singleMatch) {
-            tagMatches.push({
-                tag: singleMatch[0],
-                prompt: singleMatch[1]
-            });
-        }
-    }
-
-    if(tagMatches.length == 0){
-        alert(imgTagRegex + "  "+imgTagRegex.global)
-                alert(message.mes)
-    }
-    if (tagMatches.length > 0) {
+    // const testRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
+    let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
+    console.log(imgTagRegex, matches)
+    if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {
             try {
-                toastr.info(`Generating ${tagMatches.length} images...`);
+                toastr.info(`Generating ${matches.length} images...`);
                 const insertType = extension_settings[extensionName].insertType;
+
 
                 // 在当前消息中插入图片
                 // 初始化message.extra
@@ -417,41 +372,50 @@ async function handleIncomingMessage() {
                 // 获取消息元素用于稍后更新
                 const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
 
-                // 循环预存的匹配结果数组
-                for (let i = 0; i < tagMatches.length; i++) {
-                    const { tag: originalTag, prompt } = tagMatches[i];
+                // 处理每个匹配的图片标签
+                for (let i = 0; i < matches.length; i++) {
+                    const prompt = matches[i];
+
                     // @ts-ignore
                     const result = await SlashCommandParser.commands['sd'].callback({ quiet: insertType === INSERT_TYPE.NEW_MESSAGE ? 'false' : 'true' }, prompt);
-                    
+                    // 统一插入到extra里
                     if (insertType === INSERT_TYPE.INLINE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
                             // 添加图片到swipes数组
                             message.extra.image_swipes.push(imageUrl);
+
                             // 设置第一张图片为主图片，或更新为最新生成的图片
                             message.extra.image = imageUrl;
                             message.extra.title = prompt;
                             message.extra.inline_image = true;
+
                             // 更新UI
                             appendMediaToMessage(message, messageElement);
+
                             // 保存聊天记录
                             await context.saveChat();
                         }
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // 直接使用预存的原始标签进行替换
-                            const newImageTag = `<img src="${imageUrl}"  prompt="${prompt}">`;
+                            // Find the original image tag in the message
+                            const originalTag = message.mes.match(imgTagRegex)[0];
+                            // Replace it with an actual image tag
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" datetime='202510052258'>`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
-                            // 更新消息显示
+
+                            // Update the message display using updateMessageBlock
                             updateMessageBlock(context.chat.length - 1, message);
-                            // 保存聊天
+
+                            // Save the chat
                             await context.saveChat();
                         }
                     }
-                }
 
-                // 1. 先通过正则名称查找ID（这里假设要操作的正则名称是"状态栏美化"，可根据实际修改）
+                }
+				
+				 // 1. 先通过正则名称查找ID（这里假设要操作的正则名称是"状态栏美化"，可根据实际修改）
                 const targetRegexName = "状态栏美化"; // 替换为你的正则脚本名称
                 const targetRegexId = findGlobalRegexIdByName(targetRegexName);
                 
@@ -461,14 +425,12 @@ async function handleIncomingMessage() {
                 } else {
                     alert(`[${extensionName}] 未找到名称为"${targetRegexName}"的全局正则脚本`);
                 }
-                
-                toastr.success(`${tagMatches.length} images generated successfully`);
+				
+                toastr.success(`${matches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);
                 console.error('Image generation error:', error);
             }
-        }, 0); // 防阻塞UI渲染
+        }, 0); //防阻塞UI渲染
     }
 }
-
-

--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt},dmzz">`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" >`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -316,7 +316,6 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async function (eventDa
         toastr.error(`提示词注入错误: ${error}`);
     }
 });
-
 // 监听消息接收事件
 eventSource.on(event_types.MESSAGE_RECEIVED, handleIncomingMessage);
 async function handleIncomingMessage() {
@@ -341,16 +340,15 @@ async function handleIncomingMessage() {
         return;
     }
 
-    // 使用正则表达式search
+    // 使用正则表达式search，获取完整匹配对象（含完整标签+捕获组）
     const imgTagRegex = regexFromString(extension_settings[extensionName].promptInjection.regex);
-//const imgTagRegex = /<[\s\r\n]*img(?!(?:(?!>).)*?current_datetime\s*=\s*"[^"]*2025100522[^"]*")[^>]*?prompt\s*=\s*"([^"]*)"[^>]*?>/gis;
-	let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)].map(match => match[1]) : [message.mes.match(imgTagRegex)[1]]; // 只取捕获组的内容
+    // 核心修改：删除.map(match => match[1])，保留完整匹配信息，无需后续重复match
+    let matches = imgTagRegex.global ? [...message.mes.matchAll(imgTagRegex)] : [message.mes.match(imgTagRegex)]; 
     console.log(imgTagRegex, matches)
 
-	if(matches.length ===0){
-	   toastr.success(message.mes);
-
-	}
+    if(matches.length === 0){
+        toastr.success(message.mes);
+    }
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来
         setTimeout(async () => {
@@ -378,9 +376,11 @@ async function handleIncomingMessage() {
                 // 获取消息元素用于稍后更新
                 const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
 
-                // 处理每个匹配的图片标签
+                // 处理每个匹配的图片标签：直接从预存的matches中取数据，无重复match
                 for (let i = 0; i < matches.length; i++) {
-                    const prompt = matches[i];
+                    // 核心修改：从完整匹配对象中直接提取，无需再调用message.mes.match()
+                    const prompt = matches[i][1]; // 匹配对象的[1]为捕获组内容（即图片prompt）
+                    const originalTag = matches[i][0]; // 匹配对象的[0]为完整匹配标签（用于后续替换）
 
                     // @ts-ignore
                     const result = await SlashCommandParser.commands['sd'].callback({ quiet: insertType === INSERT_TYPE.NEW_MESSAGE ? 'false' : 'true' }, prompt);
@@ -405,27 +405,9 @@ async function handleIncomingMessage() {
                     } else if (insertType === INSERT_TYPE.REPLACE) {
                         let imageUrl = result;
                         if (typeof imageUrl === 'string' && imageUrl.trim().length > 0) {
-                            // Find the original image tag in the message
-                            const originalTag = message.mes.match(imgTagRegex)[0];
-                            alert(originalTag)
-							// Replace it with an actual image tag
-
-							// 1. 生成5位字符数组：包含1个固定'z' + 4个随机小写字母（a-z，可含重复）
-const chars = [
-  'z', // 固定字母z
-  ...Array.from({ length: 4 }, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)) // 4个随机小写字母
-];
-
-// 2. 随机打乱数组顺序，确保z的位置不固定
-chars.sort(() => Math.random() - 0.5);
-
-// 3. 拼接成"dmzz_5位字符"格式（如dmzz_zhjuy、dmzz_cdyjz）
-const dmzzStr = `dmzz_${chars.join('')}`;
-
-// 4. 生成最终img标签
-const newImageTag = `<img src="${imageUrl}" prompt="${prompt},${dmzzStr}" >`;
-alert(newImageTag)
-							message.mes = message.mes.replace(originalTag, newImageTag);
+                            // 直接使用预存的originalTag，无需重复匹配原标签
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}" >`;
+                            message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock
                             updateMessageBlock(context.chat.length - 1, message);
@@ -437,7 +419,7 @@ alert(newImageTag)
 
                 }
 
-				 // 1. 先通过正则名称查找ID（这里假设要操作的正则名称是"状态栏美化"，可根据实际修改）
+                // 1. 先通过正则名称查找ID（这里假设要操作的正则名称是"状态栏美化"，可根据实际修改）
                 const targetRegexName = "状态栏美化"; // 替换为你的正则脚本名称
                 const targetRegexId = findGlobalRegexIdByName(targetRegexName);
 
@@ -456,3 +438,7 @@ alert(newImageTag)
         }, 0); //防阻塞UI渲染
     }
 }
+
+
+
+

--- a/index.js
+++ b/index.js
@@ -348,7 +348,7 @@ async function handleIncomingMessage() {
                             // Find the original image tag in the message
                             const originalTag = message.mes.match(imgTagRegex)[0];
                             // Replace it with an actual image tag
-                            const newImageTag = `<img src="${imageUrl}" title="${prompt}" alt="${prompt}">`;
+                            const newImageTag = `<img src="${imageUrl}" prompt="${prompt}"> current_datetime='202510052258'`;
                             message.mes = message.mes.replace(originalTag, newImageTag);
 
                             // Update the message display using updateMessageBlock

--- a/index.js
+++ b/index.js
@@ -286,7 +286,7 @@ async function handleIncomingMessage() {
         const singleMatch = message.mes.match(imgTagRegex);
         matches = singleMatch ? [singleMatch] : []; // 非全局匹配时处理单个结果
     }
-  alert(matches)
+  //alert(matches)
     console.log(`[${extensionName}] 匹配到的完整标签:`, matches.map(m => m[0]));
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来

--- a/index.js
+++ b/index.js
@@ -306,8 +306,12 @@ async function handleIncomingMessage() {
                 }
 
                 // 获取消息元素用于稍后更新
-                const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
+                //const messageElement = $(`.mes[mesid="${context.chat.length - 1}"]`);
+// 关键：提前定义messageId（在所有使用它的地方之前）
+const messageId = context.chat.length - 1; 
 
+// 用定义好的messageId获取消息元素
+const messageElement = $(`.mes[mesid="${messageId}"]`);
                 // 处理每个匹配的图片标签
                 for (let i = 0; i < matches.length; i++) {
                     const prompt = matches[i];
@@ -350,8 +354,9 @@ async function handleIncomingMessage() {
                     }
 
                 }
+                alert(0);
                 eventSource.emit(event_types.MESSAGE_UPDATED, { messageId: messageId, message: message });
-
+alert(1);
                 toastr.success(`${matches.length} images generated successfully`);
             } catch (error) {
                 toastr.error(`Image generation error: ${error}`);

--- a/index.js
+++ b/index.js
@@ -347,7 +347,7 @@ async function handleIncomingMessage() {
     console.log(imgTagRegex, matches)
 
     if(matches.length === 0){
-        toastr.success(message.mes);
+    
     }
     if (matches.length > 0) {
         // 延迟执行图片生成，确保消息首先显示出来


### PR DESCRIPTION
大佬我深度体验了你的插件REPLACE模式有几个问题：
1.图片替换后的格式是<img src="" title="" alt="" >
这导致ai回复的时候经常参考这个格式输出，而不是输出世界书设定的格式比如<pic prompt="">，导致正则匹配失败。建议替换后使用<img src="" prompt="">格式，然后输入格式使用<img prompt="">，这样兼容性最好，即使ai蠢点也不影响，因为即使ai学习上下文中的<img src="" prompt="">输出通过正则也能匹配上。不然经常要roll很多次ai才听话
2.你源代码中REPLACE模式，正则匹配是for循环每次匹配，建议for循环外一次性匹配完，因为ai会参考上下文输出<img src="" prompt="" >导致第二次正则匹配时匹配不上，这个和第一个问题是一起的
3.REPLACE模式会破坏消息中的状态栏，原因应该是正则失效了，手动打开或者关闭任意正则状态栏会恢复。
第三个问题应该是要更新ui的同时重新触发下正则的事件，我尝试修复没成功。于是用了个笨办法，直接用js手动模拟点击正则开关来触发ui重新更新。

这几个问题我fork你的仓库改了下，自己使用了一段时间，没大问题，就是为了解决1 2这两个问题，正则和ai输出的图片标签格式比较定制化，不兼容现在使用master节点的用户的正则，因此建议创建一个新的分支。

只能使用这个正则:
/<[\s\r\n]*img[^>]*?prompt\s*=\s*"([^"]*)"[^>]*?>/gis
世界书中的格式只能使用：
\<img prompt=""\>
