### PR TITLE
修复行内替换模式掉格式的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,39 @@ function escapeHtmlAttribute(value) {
 }
 
 /**
+ * Reverses {@link escapeHtmlAttribute} to recover the original prompt text.
+ * @param {string} value
+ * @returns {string}
+ */
+function unescapeHtmlAttribute(value) {
+    if (typeof value !== 'string') {
+        return '';
+    }
+
+    return value
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&amp;/g, '&'); // 必须放在最后，避免二次反转义
+}
+
+/**
+ * Converts the <img> tags this extension generated in REPLACE mode back into
+ * their original <pic prompt="..."> form. Only tags carrying our data-pic-gen
+ * marker are touched, so user/character images are left untouched.
+ * @param {string} content
+ * @returns {string}
+ */
+function restorePicTags(content) {
+    return content.replace(
+        /<img\b[^>]*?\sdata-pic-gen="([^"]*)"[^>]*>/g,
+        (_match, escapedPrompt) =>
+            `<pic prompt="${unescapeHtmlAttribute(escapedPrompt)}">`,
+    );
+}
+
+/**
  * Ensures message.extra.image_swipes always exists and is an array.
  * @param {any} message
  * @returns {string[]}
@@ -300,13 +333,37 @@ eventSource.on(
     event_types.CHAT_COMPLETION_PROMPT_READY,
     async function (eventData) {
         try {
-            // 确保设置对象和promptInjection对象都存在
+            // 扩展被禁用时不做任何处理
             if (
                 !extension_settings[extensionName] ||
-                !extension_settings[extensionName].promptInjection ||
-                !extension_settings[extensionName].promptInjection.enabled ||
                 extension_settings[extensionName].insertType ===
                     INSERT_TYPE.DISABLED
+            ) {
+                return;
+            }
+
+            // 行内替换模式下，将我们生成的 <img> 标签还原成 <pic prompt="...">，
+            // 这样发送给模型的历史里只会出现 <pic> 标签，避免模型在多轮后学着直接输出 <img>。
+            if (
+                extension_settings[extensionName].insertType ===
+                    INSERT_TYPE.REPLACE &&
+                Array.isArray(eventData?.chat)
+            ) {
+                for (const entry of eventData.chat) {
+                    if (
+                        entry &&
+                        typeof entry.content === 'string' &&
+                        entry.content.includes('data-pic-gen=')
+                    ) {
+                        entry.content = restorePicTags(entry.content);
+                    }
+                }
+            }
+
+            // 提示词注入需要单独开启
+            if (
+                !extension_settings[extensionName].promptInjection ||
+                !extension_settings[extensionName].promptInjection.enabled
             ) {
                 return;
             }
@@ -473,7 +530,7 @@ async function handleIncomingMessage() {
                             // Replace it with an actual image tag
                             const escapedUrl = escapeHtmlAttribute(imageUrl);
                             const escapedPrompt = escapeHtmlAttribute(prompt);
-                            const newImageTag = `<img src="${escapedUrl}" title="${escapedPrompt}" alt="${escapedPrompt}">`;
+                            const newImageTag = `<img src="${escapedUrl}" title="${escapedPrompt}" alt="${escapedPrompt}" data-pic-gen="${escapedPrompt}">`;
                             message.mes = message.mes.replace(
                                 originalTag,
                                 newImageTag,


### PR DESCRIPTION
注意到在**行内替换模式（Inline Replace）**下，多轮对话后模型会逐渐不再输出 `<pic prompt="...">`，而是直接输出 `<img ...>`，导致正则匹配不到、不再触发自动生图。

主要原因是行内替换模式会把消息中的 `<pic prompt="...">` 直接替换成 `<img src="...">` 并写回 `message.mes`。而 `message.mes` 会被保存进聊天记录，并在之后每一轮作为历史重新发送给模型。几张图之后，assistant 的历史里充满了 `<img>` 标签，模型据此模仿，开始直接输出 `<img>`。由于 `<img>` 不匹配 `<pic ... prompt="...">` 正则，扩展无法再触发生图。

解决方案是保持显示不变（依然内联渲染 `<img>`），但让模型永远只看到 `<pic>`：

1. 生成 `<img>` 时增加一个 `data-pic-gen="<原始prompt>"` 标记属性，保存原始 prompt。
2. 在扩展已有的 `CHAT_COMPLETION_PROMPT_READY` 事件中，遍历即将发送的 `eventData.chat`，用 `restorePicTags()` 把带 `data-pic-gen` 标记的 `<img>` 还原成 `<pic prompt="...">`

这样模型历史里只会出现 `<pic>` 标签：既消除了漂移的根源，又持续以正确格式做少样本示范。

目前测试了比较容易掉格式的 deepseek，几十轮下来都没问题。